### PR TITLE
Bugfixes to Theta and time-bumped calculation

### DIFF
--- a/src/models/blackdiffusion.rs
+++ b/src/models/blackdiffusion.rs
@@ -22,6 +22,7 @@ use instruments::RcInstrument;
 use risk::BumpablePricingContext;
 use risk::Bumpable;
 use risk::Saveable;
+use risk::marketdata::MarketData;
 use risk::dependencies::DependencyCollector;
 use data::bump::Bump;
 use models::MonteCarloModel;
@@ -461,6 +462,7 @@ impl MonteCarloModel for BlackDiffusion {
     fn as_mc_context(&self) -> &MonteCarloContext { self }
     fn as_bumpable(&self) -> &Bumpable { self }
     fn as_mut_bumpable(&mut self) -> &mut Bumpable { self }
+    fn raw_market_data(&self) -> &MarketData { self.context.raw_market_data() }
 }
 
 impl MonteCarloContext for BlackDiffusion {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -9,6 +9,7 @@ use instruments::MonteCarloDependencies;
 use instruments::MonteCarloContext;
 use risk::Bumpable;
 use risk::BumpablePricingContext;
+use risk::marketdata::MarketData;
 use dates::Date;
 use dates::datetime::DateDayFraction;
 
@@ -33,6 +34,8 @@ pub trait MonteCarloModel : MonteCarloContext + Bumpable {
     /// Converts this model to a Bumpable that can be used for risk bumping
     fn as_bumpable(&self) -> &Bumpable;
     fn as_mut_bumpable(&mut self) -> &mut Bumpable;
+
+    fn raw_market_data(&self) -> &MarketData;
 }
 
 /// Timeline, which collects the information about an instrument that a model

--- a/src/risk/cache.rs
+++ b/src/risk/cache.rs
@@ -300,6 +300,7 @@ impl BumpablePricingContext for PricingContextPrefetch {
     fn as_bumpable(&self) -> &Bumpable { self }
     fn as_mut_bumpable(&mut self) -> &mut Bumpable { self }
     fn as_pricing_context(&self) -> &PricingContext { self }
+    fn raw_market_data(&self) -> &MarketData { &self.context }
 }
 
 fn to_saved(any_saved: &mut Saveable) 

--- a/src/risk/marketdata.rs
+++ b/src/risk/marketdata.rs
@@ -284,6 +284,7 @@ impl BumpablePricingContext for MarketData {
     fn as_bumpable(&self) -> &Bumpable { self }
     fn as_mut_bumpable(&mut self) -> &mut Bumpable { self }
     fn as_pricing_context(&self) -> &PricingContext { self }
+    fn raw_market_data(&self) -> &MarketData { self }
 }
 
 fn to_saved_data(save: &mut Saveable) -> Result<&mut SavedData, qm::Error> {

--- a/src/risk/mod.rs
+++ b/src/risk/mod.rs
@@ -6,6 +6,7 @@ pub mod bumptime;
 use core::qm;
 use data::bump::Bump;
 use risk::bumptime::BumpTime;
+use risk::marketdata::MarketData;
 use instruments::PricingContext;
 use risk::dependencies::DependencyCollector;
 use std::any::Any;
@@ -40,6 +41,7 @@ pub trait BumpablePricingContext: Bumpable + PricingContext {
     fn as_bumpable(&self) -> &Bumpable;
     fn as_mut_bumpable(&mut self) -> &mut Bumpable;
     fn as_pricing_context(&self) -> &PricingContext;
+    fn raw_market_data(&self) -> &MarketData;
 }
 
 /// Time bumping is done to calculate theta or time-forward greeks, such as


### PR DESCRIPTION
1. If the list of instruments is modified by the time bump, completely rebuild the pricer
2. Make the test, which claimed to be of a forward-starting European in Monte-Carlo, actually test a forward-starting European
3. Make forward calculation of a forward-starting European work in Monte-Carlo
4. Implement fixings dependencies for European options, so time bumping works for them.
5. Add a test for forward-starting Europeans in self-pricer tests. Use the test baselines as baselines for the Monte-Carlo test.