### PR TITLE
Implement DeltaGamma

### DIFF
--- a/src/data/bumpspot.rs
+++ b/src/data/bumpspot.rs
@@ -1,6 +1,7 @@
 use data::bump::Bumper;
 
 /// Bump that defines all the supported bumps to a spot value
+#[derive(Clone)]
 pub enum BumpSpot {
     Relative { bump: f64 },
     Replace { spot: f64 }

--- a/src/pricers/montecarlo.rs
+++ b/src/pricers/montecarlo.rs
@@ -128,7 +128,7 @@ impl Pricer for MonteCarloPricer {
 }
 
 impl Bumpable for MonteCarloPricer {
-    fn bump(&mut self, bump: &Bump, save: &mut Saveable)
+    fn bump(&mut self, bump: &Bump, save: Option<&mut Saveable>)
         -> Result<bool, qm::Error> {
         self.model.bump(bump, save)
     }
@@ -213,7 +213,7 @@ mod tests {
         // now bump the spot and price. Note that this equates to roughly
         // delta of 0.5, which is what we expect for an atm option
         let bump = Bump::new_spot("BP.L", BumpSpot::new_relative(0.01));
-        let bumped = pricer.as_mut_bumpable().bump(&bump, &mut *save).unwrap();
+        let bumped = pricer.as_mut_bumpable().bump(&bump, Some(&mut *save)).unwrap();
         assert!(bumped);
         let bumped_price = pricer.price().unwrap();
         assert_approx(bumped_price - unbumped_price, 0.633187905501792, 0.01);
@@ -227,7 +227,7 @@ mod tests {
         // now bump the vol and price. The new price is a bit larger, as
         // expected. (An atm option has roughly max vega.)
         let bump = Bump::new_vol("BP.L", BumpVol::new_flat_additive(0.01));
-        let bumped = pricer.as_mut_bumpable().bump(&bump, &mut *save).unwrap();
+        let bumped = pricer.as_mut_bumpable().bump(&bump, Some(&mut *save)).unwrap();
         assert!(bumped);
         let bumped_price = pricer.price().unwrap();
         assert_approx(bumped_price - unbumped_price, 0.429105019892687, 0.02);
@@ -241,7 +241,7 @@ mod tests {
         // now bump the divs and price. As expected, this makes the
         // price decrease by a small amount.
         let bump = Bump::new_divs("BP.L", BumpDivs::new_all_relative(0.01));
-        let bumped = pricer.as_mut_bumpable().bump(&bump, &mut *save).unwrap();
+        let bumped = pricer.as_mut_bumpable().bump(&bump, Some(&mut *save)).unwrap();
         assert!(bumped);
         let bumped_price = pricer.price().unwrap();
         assert_approx(bumped_price - unbumped_price, -0.01968507722361, 0.001);
@@ -255,7 +255,7 @@ mod tests {
         // now bump the yield underlying the equity and price. This
         // increases the forward, so we expect the call price to increase.
         let bump = Bump::new_yield("LSE", BumpYield::new_flat_annualised(0.01));
-        let bumped = pricer.as_mut_bumpable().bump(&bump, &mut *save).unwrap();
+        let bumped = pricer.as_mut_bumpable().bump(&bump, Some(&mut *save)).unwrap();
         assert!(bumped);
         let bumped_price = pricer.price().unwrap();
         assert_approx(bumped_price - unbumped_price, 0.814646953109683, 0.01);
@@ -268,7 +268,7 @@ mod tests {
 
         // now bump the yield underlying the option and price
         let bump = Bump::new_yield("OPT", BumpYield::new_flat_annualised(0.01));
-        let bumped = pricer.as_mut_bumpable().bump(&bump, &mut *save).unwrap();
+        let bumped = pricer.as_mut_bumpable().bump(&bump, Some(&mut *save)).unwrap();
         assert!(bumped);
         let bumped_price = pricer.price().unwrap();
         assert_approx(bumped_price - unbumped_price, -0.215250594911648, 0.01);
@@ -307,7 +307,7 @@ mod tests {
         // the skew.
         let mut save = pricer.as_bumpable().new_saveable();
         let bump = Bump::new_spot("BP.L", BumpSpot::new_relative(0.01));
-        let bumped = pricer.as_mut_bumpable().bump(&bump, &mut *save).unwrap();
+        let bumped = pricer.as_mut_bumpable().bump(&bump, Some(&mut *save)).unwrap();
         assert!(bumped);
         let bumped_price = pricer.price().unwrap();
         assert_approx(bumped_price - unbumped_price, 0.20514185426620202, 0.01);
@@ -324,7 +324,7 @@ mod tests {
         assert_approx(bumped_price - unbumped_price, 0.013084492446001406, 0.3);
 
         // again test the delta -- should now be much larger
-        let bumped = pricer.as_mut_bumpable().bump(&bump, &mut *save).unwrap();
+        let bumped = pricer.as_mut_bumpable().bump(&bump, Some(&mut *save)).unwrap();
         assert!(bumped);
         let delta_bumped_price = pricer.price().unwrap();
         assert_approx(delta_bumped_price - bumped_price, 0.6824796398724473, 0.01);

--- a/src/pricers/selfpricer.rs
+++ b/src/pricers/selfpricer.rs
@@ -101,7 +101,7 @@ impl Pricer for SelfPricer {
 }
 
 impl Bumpable for SelfPricer {
-    fn bump(&mut self, bump: &Bump, save: &mut Saveable)
+    fn bump(&mut self, bump: &Bump, save: Option<&mut Saveable>)
         -> Result<bool, qm::Error> {
         self.context.bump(bump, save)
     }
@@ -174,7 +174,7 @@ mod tests {
         // now bump the spot and price. Note that this equates to roughly
         // delta of 0.5, which is what we expect for an atm option
         let bump = Bump::new_spot("BP.L", BumpSpot::new_relative(0.01));
-        let bumped = pricer.as_mut_bumpable().bump(&bump, &mut *save).unwrap();
+        let bumped = pricer.as_mut_bumpable().bump(&bump, Some(&mut *save)).unwrap();
         assert!(bumped);
         let bumped_price = pricer.price().unwrap();
         assert_approx(bumped_price, 17.343905306334765, 1e-12);
@@ -188,7 +188,7 @@ mod tests {
         // now bump the vol and price. The new price is a bit larger, as
         // expected. (An atm option has roughly max vega.)
         let bump = Bump::new_vol("BP.L", BumpVol::new_flat_additive(0.01));
-        let bumped = pricer.as_mut_bumpable().bump(&bump, &mut *save).unwrap();
+        let bumped = pricer.as_mut_bumpable().bump(&bump, Some(&mut *save)).unwrap();
         assert!(bumped);
         let bumped_price = pricer.price().unwrap();
         assert_approx(bumped_price, 17.13982242072566, 1e-12);
@@ -202,7 +202,7 @@ mod tests {
         // now bump the divs and price. As expected, this makes the
         // price decrease by a small amount.
         let bump = Bump::new_divs("BP.L", BumpDivs::new_all_relative(0.01));
-        let bumped = pricer.as_mut_bumpable().bump(&bump, &mut *save).unwrap();
+        let bumped = pricer.as_mut_bumpable().bump(&bump, Some(&mut *save)).unwrap();
         assert!(bumped);
         let bumped_price = pricer.price().unwrap();
         assert_approx(bumped_price, 16.691032323609356, 1e-12);
@@ -216,7 +216,7 @@ mod tests {
         // now bump the yield underlying the equity and price. This
         // increases the forward, so we expect the call price to increase.
         let bump = Bump::new_yield("LSE", BumpYield::new_flat_annualised(0.01));
-        let bumped = pricer.as_mut_bumpable().bump(&bump, &mut *save).unwrap();
+        let bumped = pricer.as_mut_bumpable().bump(&bump, Some(&mut *save)).unwrap();
         assert!(bumped);
         let bumped_price = pricer.price().unwrap();
         assert_approx(bumped_price, 17.525364353942656, 1e-12);
@@ -229,7 +229,7 @@ mod tests {
 
         // now bump the yield underlying the option and price
         let bump = Bump::new_yield("OPT", BumpYield::new_flat_annualised(0.01));
-        let bumped = pricer.as_mut_bumpable().bump(&bump, &mut *save).unwrap();
+        let bumped = pricer.as_mut_bumpable().bump(&bump, Some(&mut *save)).unwrap();
         assert!(bumped);
         let bumped_price = pricer.price().unwrap();
         assert_approx(bumped_price, 16.495466805921325, 1e-12);
@@ -258,7 +258,7 @@ mod tests {
         // the skew.
         let mut save = pricer.as_bumpable().new_saveable();
         let bump = Bump::new_spot("BP.L", BumpSpot::new_relative(0.01));
-        let bumped = pricer.as_mut_bumpable().bump(&bump, &mut *save).unwrap();
+        let bumped = pricer.as_mut_bumpable().bump(&bump, Some(&mut *save)).unwrap();
         assert!(bumped);
         let bumped_price = pricer.price().unwrap();
         assert_approx(bumped_price - unbumped_price, 0.20514185426620202, 1e-12);
@@ -274,7 +274,7 @@ mod tests {
         assert_approx(bumped_price - unbumped_price, 0.013084492446001406, 1e-12);
 
         // again test the delta -- should now be much larger
-        let bumped = pricer.as_mut_bumpable().bump(&bump, &mut *save).unwrap();
+        let bumped = pricer.as_mut_bumpable().bump(&bump, Some(&mut *save)).unwrap();
         assert!(bumped);
         let delta_bumped_price = pricer.price().unwrap();
         assert_approx(delta_bumped_price - bumped_price, 0.6824796398724473, 1e-12);

--- a/src/risk/bumptime.rs
+++ b/src/risk/bumptime.rs
@@ -39,14 +39,12 @@ impl BumpTime {
         let modified = self.update_instruments(
             instruments, bumpable.context(), bumpable.dependencies()?)?;
         
-        // Now apply a bump to the model, to shift the spot date. We create a saveable area
-        // just to simplify the code. It is not used to actually save anything. If the
+        // Now apply a bump to the model, to shift the spot date. If the
         // instrument list has been modified, things are more serious. We do nothing, and leave
         // it to the caller to rebuild things from scratch.
         if !modified {
-            let mut saveable = bumpable.new_saveable();
             let bump = Bump::new_spot_date(self.spot_date_bump.clone());
-            bumpable.bump(&bump, &mut *saveable)?;
+            bumpable.bump(&bump, None)?;
         }
         Ok(modified)
     }

--- a/src/risk/deltagamma.rs
+++ b/src/risk/deltagamma.rs
@@ -1,0 +1,199 @@
+use std::collections::HashMap;
+use std::any::Any;
+use risk::Report;
+use risk::ReportGenerator;
+use risk::Pricer;
+use risk::Saveable;
+use risk::bumped_price;
+use data::bump::Bump;
+use data::bumpspot::BumpSpot;
+use core::qm;
+
+/// Delta is the first derivative of price with respect to the spot value
+/// of an underlying. Gamma is the second derivative. This report shows
+/// the delta and gamma with respect to each of the underlyings
+/// that affect the price.
+pub struct DeltaGammaReport {
+    results: HashMap<String, DeltaGamma>
+}
+
+impl Report for DeltaGammaReport {
+    fn as_any(&self) -> &Any { self }
+}
+
+impl DeltaGammaReport {
+    pub fn results(&self) -> &HashMap<String, DeltaGamma> { &self.results }
+}
+
+pub struct DeltaGamma {
+    delta: f64,
+    gamma: f64
+}
+
+impl DeltaGamma {
+    pub fn delta(&self) -> f64 { self.delta }
+    pub fn gamma(&self) -> f64 { self.gamma }
+}
+
+/// Calculator for delta and gamma by bumping. The bump size is specified as
+/// a fraction of the current spot.
+pub struct DeltaGammaReportGenerator {
+    bumpsize: f64
+}
+
+impl DeltaGammaReportGenerator {
+    pub fn new(bumpsize: f64) -> DeltaGammaReportGenerator {
+        DeltaGammaReportGenerator { bumpsize: bumpsize }
+    }
+}
+
+impl ReportGenerator for DeltaGammaReportGenerator {
+    fn generate(&self, pricer: &mut Pricer, saveable: &mut Saveable, unbumped: f64)
+        -> Result<Box<Report>, qm::Error> {
+
+        // We first bump up by 1 + bumpsize, then down by (1 - bumpsize) / (1 + bumpsize)
+        // so we cancel out the original up bump. This saves time compared
+        // with restoring between the bumps.
+        let down_bump = (1.0 - self.bumpsize) / (1.0 + self.bumpsize) - 1.0;
+        let up = BumpSpot::new_relative(self.bumpsize);
+        let down = BumpSpot::new_relative(down_bump);
+
+        // Find the underlyings we should have delta to. Note that we need to
+        // clone the list of instruments, to avoid borrowing problems.
+        let instruments = pricer.as_bumpable().dependencies()?.instruments_clone();
+        let mut results = HashMap::new();
+        for id in instruments.iter() {
+
+            let spot = pricer.as_bumpable().context().spot(id)?;
+
+            // bump up and reprice
+            let bump = Bump::new_spot(id, up.clone());
+            let upbumped = bumped_price(&bump, pricer, Some(saveable), unbumped)?;
+            
+            // bump down and reprice (do not save the result from this)
+            let bump = Bump::new_spot(id, down.clone());
+            let downbumped = bumped_price(&bump, pricer, None, unbumped)?;
+
+            pricer.as_mut_bumpable().restore(saveable)?;
+            saveable.clear();
+
+            // delta and gamma calculations
+            let bumpsize = self.bumpsize * spot;
+            let delta = (upbumped - downbumped) / (2.0 * bumpsize);
+            let gamma = (upbumped + downbumped - 2.0 * unbumped) / bumpsize.powi(2);
+            results.insert(id.to_string(), DeltaGamma {delta, gamma});
+        }
+
+        Ok(Box::new(DeltaGammaReport { results: results }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::rc::Rc;
+    use math::numerics::approx_eq;
+    use risk::marketdata::tests::sample_market_data;
+    use risk::marketdata::tests::sample_european;
+    use risk::Bumpable;
+    use risk::TimeBumpable;
+    use risk::bumptime::BumpTime;
+    use risk::dependencies::DependencyCollector;
+    use risk::cache::PricingContextPrefetch;
+    use instruments::options::SpotStartingEuropean;
+    use instruments::PricingContext;
+    use instruments::Instrument;
+    use instruments::Priceable;
+    use risk::cache::tests::create_dependencies;
+
+    // a sample pricer that evaluates european options
+    struct SamplePricer {
+        option: Rc<SpotStartingEuropean>,
+        context: PricingContextPrefetch
+    }
+
+    pub fn sample_pricer() -> Box<Pricer> {
+
+        let market_data = sample_market_data();
+        let european = sample_european();
+ 
+        let spot_date = market_data.spot_date();
+        let instrument: Rc<Instrument> = european.clone();
+        let dependencies = create_dependencies(&instrument, spot_date);
+        let context = PricingContextPrefetch::new(&market_data,
+            dependencies).unwrap();
+ 
+        Box::new(SamplePricer {
+            option: european,
+            context: context
+        })
+    }
+
+    impl Pricer for SamplePricer {
+        fn as_bumpable(&self) -> &Bumpable { self }
+        fn as_mut_bumpable(&mut self) -> &mut Bumpable { self }
+        fn as_mut_time_bumpable(&mut self) -> &mut TimeBumpable { self }
+
+        fn price(&self) -> Result<f64, qm::Error> {
+            self.option.price(&self.context)
+        }
+    }
+
+    impl Bumpable for SamplePricer {
+        fn bump(&mut self, bump: &Bump, save: Option<&mut Saveable>) -> Result<bool, qm::Error> {
+            self.context.bump(bump, save)
+        }
+        fn dependencies(&self) -> Result<&DependencyCollector, qm::Error> {
+            self.context.dependencies()
+        }
+        fn context(&self) -> &PricingContext {
+            &self.context
+        }
+        fn new_saveable(&self) -> Box<Saveable> {
+            self.context.new_saveable()
+        }
+        fn restore(&mut self, saved: &Saveable) -> Result<(), qm::Error> {
+            self.context.restore(saved)
+        }
+    }
+
+    impl TimeBumpable for SamplePricer {
+        fn bump_time(&mut self, _bump: &BumpTime) -> Result<(), qm::Error> {
+            Err(qm::Error::new("time bumps not supported"))
+        }
+    }
+
+    #[test]
+    fn delta_gamma_european() {
+
+        // create a pricer for a european at the money call
+        let mut pricer = sample_pricer();
+        let unbumped = pricer.price().unwrap();
+        assert_approx(unbumped, 16.710717400832973, 1e-12);
+
+        // calculate delta with a one percent bump
+        let generator = DeltaGammaReportGenerator::new(0.01);
+        let mut save = pricer.as_bumpable().new_saveable();
+        let report = generator.generate(&mut *pricer, &mut *save, unbumped).unwrap();
+        let results = report.as_any().downcast_ref::<DeltaGammaReport>().unwrap().results();
+        assert!(results.len() == 1);
+        let delta_gamma = results.get("BP.L").unwrap();
+        assert_approx(delta_gamma.delta(), 0.6280984326807371, 1e-12);
+        assert_approx(delta_gamma.gamma(), 0.010178945642110193, 1e-12);
+
+        // calculate delta with a one bp bump (the results are very close to the
+        // one percent bump)
+        let generator = DeltaGammaReportGenerator::new(0.0001);
+        let report = generator.generate(&mut *pricer, &mut *save, unbumped).unwrap();
+        let results = report.as_any().downcast_ref::<DeltaGammaReport>().unwrap().results();
+        assert!(results.len() == 1);
+        let delta_gamma = results.get("BP.L").unwrap();
+        assert_approx(delta_gamma.delta(), 0.6281335819139144, 1e-12);
+        assert_approx(delta_gamma.gamma(), 0.010179072518212706, 1e-12);
+    }
+
+    fn assert_approx(value: f64, expected: f64, tolerance: f64) {
+        assert!(approx_eq(value, expected, tolerance),
+            "value={} expected={}", value, expected);
+    }
+}

--- a/src/risk/dependencies.rs
+++ b/src/risk/dependencies.rs
@@ -95,6 +95,12 @@ impl DependencyCollector {
         self.instruments.insert(
             instrument.id().to_string(), instrument.clone());
     }
+
+    pub fn instruments_clone(&self) -> Vec<String> {
+        // this rather unpleasant syntax forces the ids to be owned
+        // by the resulting vector rather than the original hashmap
+        self.instruments.keys().map(|id|id.to_string()).collect()
+    }
 }
 
 fn get_hwm_by_str(map: &HashMap<String, Date>, id: &str) -> Option<Date> {


### PR DESCRIPTION
Add a generic methodology for generating risk reports. Add the first of these, DeltaGamma, which produces a report of Delta and Gamma for all the underlyings of a pricer.

In terms of implementation, I have changed the bump method of Bumpable to allow the save parameter to be optional. This is because the most efficient way to calculate a symmetric delta is to bump first up then down, without restoring in between. This means the down bump does not need to save its old state. This change was very difficult -- there seems to be a lack of support in Rust for Option. For example, Option is not cloneable, which means it is very hard to avoid borrow problems.