### PR TITLE
Time-forward greeks and Theta

### DIFF
--- a/src/math/brent.rs
+++ b/src/math/brent.rs
@@ -123,4 +123,31 @@ mod tests {
             assert!(approx_eq(y, expected, tol), "result={} expected={}", v, expected);
         }
     }
+
+    #[test]
+    fn problem_of_the_day() {
+
+        // Stretch a piece of rope around the equator. Now add one meter to the length of
+        // the rope. How tall a tent-pole can you now stand on the equator such that the
+        // rope goes over the top?
+
+        let r = 6.371e6_f64;
+        let min = 0.0;
+        let max = 1e8;
+        let max_iter = 100;
+        let tol = 1e-10;
+
+        // use Brent to find the answer
+        let y = zbrent(min, max, tol, max_iter, &mut |h| 
+            Ok(1.0 + r * (r / (r + h)).acos() - (h * (2.0 * r + h)).sqrt())).unwrap();
+
+        // check the answer against a hard-coded number
+        let expected = 192.80752497643797_f64;
+        assert!(approx_eq(y, expected, tol), "result={} expected={}", y, expected);
+
+        // check that our answer solves the problem
+        let test_expected = 1.0 + r * (r / (r + expected)).acos() 
+            - (expected * (2.0 * r + expected)).sqrt();
+        assert!(approx_eq(test_expected, 0.0, 1e-8), "result={} expected={}", test_expected, 0.0);
+    }
 }

--- a/src/models/blackdiffusion.rs
+++ b/src/models/blackdiffusion.rs
@@ -106,6 +106,7 @@ impl MonteCarloModelFactory for BlackDiffusionFactory {
 /// line up. Where some assets really have more observations than others, we
 /// need fancier handling, either in the maths of the correlation matrix, or
 /// by evolving over the union of the dates, then discarding some. 
+#[derive(Clone)]
 pub struct BlackDiffusion {
     observations: Vec<DateDayFraction>,
     flows: Vec<Rc<Instrument>>,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,6 +1,7 @@
 pub mod blackdiffusion;
 
 use std::collections::HashMap;
+use std::clone::Clone;
 use std::rc::Rc;
 use core::qm;
 use instruments::RcInstrument;
@@ -26,7 +27,7 @@ pub trait MonteCarloModelFactory {
 
 /// Interface that must be implemented by a model in order to support
 /// Monte-Carlo pricing.
-pub trait MonteCarloModel : MonteCarloContext + Bumpable {
+pub trait MonteCarloModel : MonteCarloContext + Bumpable + MonteCarloModelClone {
 
     /// Converts this model to a MonteCarloContext that can be used for pricing
     fn as_mc_context(&self) -> &MonteCarloContext;
@@ -36,6 +37,24 @@ pub trait MonteCarloModel : MonteCarloContext + Bumpable {
     fn as_mut_bumpable(&mut self) -> &mut Bumpable;
 
     fn raw_market_data(&self) -> &MarketData;
+}
+
+pub trait MonteCarloModelClone {
+    fn clone_box(&self) -> Box<MonteCarloModel>;
+}
+
+impl<T> MonteCarloModelClone for T
+    where T: 'static + MonteCarloModel + Clone,
+{
+    fn clone_box(&self) -> Box<MonteCarloModel> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<MonteCarloModel> {
+    fn clone(&self) -> Box<MonteCarloModel> {
+        self.clone_box()
+    }
 }
 
 /// Timeline, which collects the information about an instrument that a model

--- a/src/pricers/selfpricer.rs
+++ b/src/pricers/selfpricer.rs
@@ -5,6 +5,7 @@ use instruments::PricingContext;
 use instruments::DependencyContext;
 use risk::cache::PricingContextPrefetch;
 use risk::Pricer;
+use risk::PricerClone;
 use risk::dependencies::DependencyCollector;
 use risk::Bumpable;
 use risk::TimeBumpable;
@@ -19,6 +20,7 @@ use risk::marketdata::MarketData;
 /// The SelfPricer calculator uses the Priceable interface of an
 /// instrument to evaluate the instrument . It then exposes this
 /// interface as a Pricer, allowing bumping for risk calculation.
+#[derive(Clone)]
 pub struct SelfPricer {
     instruments: Vec<(f64, Rc<Instrument>)>,
     context: PricingContextPrefetch
@@ -98,6 +100,10 @@ impl Pricer for SelfPricer {
         }
         Ok(total)
     }
+}
+
+impl PricerClone for SelfPricer {
+    fn clone_box(&self) -> Box<Pricer> { Box::new(self.clone()) }
 }
 
 impl Bumpable for SelfPricer {

--- a/src/risk/cache.rs
+++ b/src/risk/cache.rs
@@ -21,7 +21,7 @@ use core::qm;
 /// needed for calculations. Although the module is called cache, the behaviour
 /// is entirely deterministic. We prefetch the data, rather than lazily caching
 /// it.
-
+#[derive(Clone)]
 pub struct PricingContextPrefetch {
     context: MarketData,
     dependencies: Rc<DependencyCollector>,

--- a/src/risk/timebumped.rs
+++ b/src/risk/timebumped.rs
@@ -1,0 +1,146 @@
+use risk::Report;
+use risk::ReportGenerator;
+use risk::Pricer;
+use risk::Saveable;
+use risk::bumptime::BumpTime;
+use std::any::Any;
+use core::qm;
+
+/// A report of price and risks calculated as of a future date. If no
+/// subreports are requested, it is just a Theta calculator.
+pub struct TimeBumpedReport {
+    price: f64,
+    theta: f64,
+    subreports: Vec<Box<Report>>
+}
+
+impl Report for TimeBumpedReport {
+    fn as_any(&self) -> &Any { self }
+}
+
+impl TimeBumpedReport {
+    pub fn new(price: f64, theta: f64, subreports: Vec<Box<Report>>) -> TimeBumpedReport {
+        TimeBumpedReport { price, theta, subreports }
+    }
+
+    pub fn price(&self) -> f64 { self.price }
+    pub fn theta(&self) -> f64 { self.theta }
+    pub fn subreports(&self) -> &[Box<Report>] { &self.subreports }
+}
+
+/// Calculator for time-forward values. The date to bump to, and which dates
+/// to bump and how are specified in a BumpTime.
+pub struct TimeBumpedReportGenerator {
+    bump: BumpTime,
+    subgenerators: Vec<Box<ReportGenerator>>
+}
+
+impl TimeBumpedReportGenerator {
+    /// Creates a new TimeBumpedReport generator, which initially just calculates
+    /// theta.
+    pub fn new(bump: BumpTime) -> TimeBumpedReportGenerator {
+        TimeBumpedReportGenerator { bump, subgenerators: Vec::new() }
+    }
+
+    /// Adds a subgenerator, for example calculating delta within the time-forward
+    /// context.
+    pub fn add(&mut self, generator: Box<ReportGenerator>) {
+        self.subgenerators.push(generator);
+    }
+}
+
+impl ReportGenerator for TimeBumpedReportGenerator {
+    fn generate(&self, pricer: &mut Pricer, saveable: &mut Saveable, unbumped: f64)
+        -> Result<Box<Report>, qm::Error> {
+        
+        // The time bump irreversibly modifies the pricer. Make a clone of it, to ensure
+        // we do not modify the original
+        let mut pricer_clone = pricer.clone_box();
+    
+        // apply the time bump to the cloned pricer
+        pricer_clone.bump_time(&self.bump)?;
+
+        // calculate the bumped price
+        let time_bumped = pricer_clone.price()?;
+        let theta = time_bumped - unbumped;
+        let mut subreports = Vec::new();
+
+        // evaluate each of the bumped reports
+        for subgenerator in self.subgenerators.iter() {
+            let report = subgenerator.generate(&mut *pricer_clone, saveable, time_bumped)?;
+            subreports.push(report);
+        }
+
+        Ok(Box::new(TimeBumpedReport::new(time_bumped, theta, subreports)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use math::numerics::approx_eq;
+    use risk::deltagamma::tests::sample_pricer;
+    use risk::deltagamma::DeltaGammaReportGenerator;
+    use risk::deltagamma::DeltaGammaReport;
+    use risk::vegavolga::VegaVolgaReportGenerator;
+    use risk::vegavolga::VegaVolgaReport;
+    use data::bumpspotdate::SpotDynamics;
+    use data::bumpvol::BumpVol;
+
+    #[test]
+    fn theta_european_call() {
+        // create a pricer for a european at the money call
+        let mut pricer = sample_pricer();
+        let unbumped = pricer.price().unwrap();
+        assert_approx(unbumped, 16.710717400832973, 1e-12);
+
+        // calculate theta by bumping forward by one day
+        let theta_date = pricer.as_bumpable().context().spot_date() + 1;
+        let bump = BumpTime::new(theta_date, theta_date, SpotDynamics::StickyForward);
+        let generator = TimeBumpedReportGenerator::new(bump);
+        let mut save = pricer.as_bumpable().new_saveable();
+        let report = generator.generate(&mut *pricer, &mut *save, unbumped).unwrap();
+        let results = report.as_any().downcast_ref::<TimeBumpedReport>().unwrap();
+        assert_approx(results.price(), 16.696665883860128, 1e-12);
+        assert_approx(results.theta(), -0.014051516972845235, 1e-12);
+    }
+
+    #[test]
+    fn time_forward_greeks_european_call() {
+        // create a pricer for a european at the money call
+        let mut pricer = sample_pricer();
+        let unbumped = pricer.price().unwrap();
+        
+        // calculate theta and contained greeks by bumping forward by one day
+        let theta_date = pricer.as_bumpable().context().spot_date() + 1;
+        let bump = BumpTime::new(theta_date, theta_date, SpotDynamics::StickyForward);
+        let mut generator = TimeBumpedReportGenerator::new(bump);
+        generator.add(Box::new(DeltaGammaReportGenerator::new(0.01)));
+        generator.add(Box::new(VegaVolgaReportGenerator::new(BumpVol::new_flat_additive(0.01))));
+        let mut save = pricer.as_bumpable().new_saveable();
+        let report = generator.generate(&mut *pricer, &mut *save, unbumped).unwrap();
+        let results = report.as_any().downcast_ref::<TimeBumpedReport>().unwrap();
+        assert_approx(results.price(), 16.696665883860128, 1e-12);
+        assert_approx(results.theta(), -0.014051516972845235, 1e-12);
+
+        let subreports = results.subreports();
+        assert_eq!(subreports.len(), 2);
+        let delta_gammas = subreports[0].as_any().downcast_ref::<DeltaGammaReport>().unwrap();
+        let vega_volgas = subreports[1].as_any().downcast_ref::<VegaVolgaReport>().unwrap();
+        let delta_gamma = delta_gammas.results().get("BP.L").unwrap();
+        let vega_volga = vega_volgas.results().get("BP.L").unwrap();
+        assert_approx(delta_gamma.delta(), 0.6281208393656919, 1e-12);
+        assert_approx(delta_gamma.gamma(), 0.010191192195037715, 1e-12);
+        assert_approx(vega_volga.vega(), 42.43387126583844, 1e-12);
+        assert_approx(vega_volga.volga(), 85.42405378449303, 1e-12);
+
+        // validate that the original pricer is unchanged
+        let finally = pricer.price().unwrap();
+        assert_approx(finally, unbumped, 1e-14);
+    }
+
+    fn assert_approx(value: f64, expected: f64, tolerance: f64) {
+        assert!(approx_eq(value, expected, tolerance),
+            "value={} expected={}", value, expected);
+    }
+}


### PR DESCRIPTION
Add a new report, TimeBumpedReport, which reports time bumped price, theta and, if you ask for them, recursively contained sub-reports.