### PR TITLE
Pass val_date(s) to priceable.price method

### DIFF
--- a/src/data/bump.rs
+++ b/src/data/bump.rs
@@ -3,7 +3,6 @@ use data::bumpdivs::BumpDivs;
 use data::bumpvol::BumpVol;
 use data::bumpyield::BumpYield;
 use data::bumpspotdate::BumpSpotDate;
-use dates::Date;
 
 /// Enumeration spanning all bumps of market data
 pub enum Bump {
@@ -12,7 +11,6 @@ pub enum Bump {
     Borrow ( String, BumpYield ),
     Vol ( String, BumpVol ),
     Yield ( String, BumpYield ),
-    DiscountDate ( Date ),
     SpotDate ( BumpSpotDate )
 }
 
@@ -35,10 +33,6 @@ impl Bump {
 
     pub fn new_yield(credit_id: &str, bump: BumpYield) -> Bump {
         Bump::Yield ( credit_id.to_string(), bump )
-    }
-
-    pub fn new_discount_date(replacement: Date) -> Bump {
-        Bump::DiscountDate ( replacement )
     }
 
     pub fn new_spot_date(bump: BumpSpotDate) -> Bump {

--- a/src/data/curves.rs
+++ b/src/data/curves.rs
@@ -128,7 +128,7 @@ impl RateCurve for AnnualisedFlatBump {
         //
         // Bumping the annualised yield gives
         // exp(rt_bumped) = (y + dy)^t = (exp(rt)^(1/t) + dy)^t
-        //
+        //  
         // Thus rt_bumped = log((exp(rt)^(1/t) + dy)^t) 
         //                = t * log(exp(rt)^(1/t) + dy)
         //                = t * log(exp(r) + dy)

--- a/src/dates/datetime.rs
+++ b/src/dates/datetime.rs
@@ -110,6 +110,14 @@ impl AddAssign<i32> for DateDayFraction {
     }
 }
 
+impl Ord for DateDayFraction {
+    fn cmp(&self, other: &DateDayFraction) -> Ordering {
+        self.partial_cmp(&other).expect("Non-orderable day fraction found in DateDayFraction")
+    }
+}
+
+impl Eq for DateDayFraction {}
+
 /// Do not implement Sub and SubAssign, as the result of these operations is
 /// unlikely to make sense. Note that the DayFraction is a measure of vol time,
 /// but the subtraction of the dates would give a measure of calendar time.

--- a/src/risk/bumptime.rs
+++ b/src/risk/bumptime.rs
@@ -39,13 +39,14 @@ impl BumpTime {
         let modified = self.update_instruments(
             instruments, bumpable.context(), bumpable.dependencies()?)?;
         
-        // Now apply a bump to the model, to shift the spot date. If the
-        // instrument list has been modified, things are more serious. We do nothing, and leave
-        // it to the caller to rebuild things from scratch.
-        if !modified {
-            let bump = Bump::new_spot_date(self.spot_date_bump.clone());
-            bumpable.bump(&bump, None)?;
-        }
+        // Now apply a bump to the model, to shift the spot date. (TODO it may be inefficient to
+        // completely refetch all dependent data if the model will need rebuilding anyway. Maybe
+        // pass the modified flag into the new_spot_date bump so the model knows not to do the
+        // work.)
+        let bump = Bump::new_spot_date(self.spot_date_bump.clone());
+        bumpable.bump(&bump, None)?;
+
+        // If the instruments have been modified, we may need to rebuild the model from scratch
         Ok(modified)
     }
 

--- a/src/risk/deltagamma.rs
+++ b/src/risk/deltagamma.rs
@@ -104,6 +104,8 @@ pub mod tests {
     use instruments::PricingContext;
     use instruments::Instrument;
     use risk::cache::tests::create_dependencies;
+    use dates::datetime::DateTime;
+    use dates::datetime::TimeOfDay;
 
     // a sample pricer that evaluates european options
     #[derive(Clone)]
@@ -137,7 +139,8 @@ pub mod tests {
         fn price(&self) -> Result<f64, qm::Error> {
             assert!(self.instruments.len() == 1);
             let instrument = self.instruments[0].1.clone();
-            instrument.as_priceable().unwrap().price(&self.context)
+            let val_date = DateTime::new(self.context.spot_date(), TimeOfDay::Open);
+            instrument.as_priceable().unwrap().price(&self.context, val_date)
         }
     }
 
@@ -199,7 +202,7 @@ pub mod tests {
         assert!(results.len() == 1);
         let delta_gamma = results.get("BP.L").unwrap();
         assert_approx(delta_gamma.delta(), 0.6281335819139144, 1e-12);
-        assert_approx(delta_gamma.gamma(), 0.010179072518212706, 1e-12);
+        assert_approx(delta_gamma.gamma(), 0.01017907258926698, 1e-12);
     }
 
     fn assert_approx(value: f64, expected: f64, tolerance: f64) {

--- a/src/risk/mod.rs
+++ b/src/risk/mod.rs
@@ -12,6 +12,7 @@ use risk::bumptime::BumpTime;
 use risk::marketdata::MarketData;
 use instruments::PricingContext;
 use risk::dependencies::DependencyCollector;
+//use dates::Date;
 use std::any::Any;
 
 /// Interface that defines all bumps of simple underlying market data. This
@@ -84,9 +85,17 @@ pub trait Pricer : Bumpable + TimeBumpable + PricerClone {
     fn as_mut_bumpable(&mut self) -> &mut Bumpable;
     fn as_mut_time_bumpable(&mut self) -> &mut TimeBumpable;
     
-    /// Returns the present value, discounted to the discount date expressed
-    /// in the pricing context.
-    fn price(&self) -> Result<f64, qm::Error>;
+    /// Returns the present value. If no discount date is supplied, the value
+    /// is discounted to the settlement date of the instrument being priced.
+    /// This means that every listed instrument should give a price equal to
+    /// the current screen price. If you supply a discount date, the value is
+    /// discounted to that date. This allows you to view prices that are
+    /// consistent across different exchanges, but it is not possible to choose
+    /// a discount date such that all values equal their screen prices, unless
+    /// all underlyings have the same settlement date.
+    /// 
+    /// Discount date is currently disabled.
+    fn price(&self /*, discount_date: Option<Date>*/) -> Result<f64, qm::Error>;
 }
 
 /// For some reason that I do not understand, the rust compiler runs into an

--- a/src/risk/vegavolga.rs
+++ b/src/risk/vegavolga.rs
@@ -119,8 +119,8 @@ mod tests {
         let results = report.as_any().downcast_ref::<VegaVolgaReport>().unwrap().results();
         assert!(results.len() == 1);
         let vega_volga = results.get("BP.L").unwrap();
-        assert_approx(vega_volga.vega(), 42.90462273386808, 1e-12);
-        assert_approx(vega_volga.volga(), 86.34909463012264, 1e-12);
+        assert_approx(vega_volga.vega(), 42.904622733885844, 1e-12);
+        assert_approx(vega_volga.volga(), 86.34909534066537, 1e-12);
     }
 
     fn assert_approx(value: f64, expected: f64, tolerance: f64) {


### PR DESCRIPTION
Previously, the priceable.price method always valued as of the spot date. It can now evaluate as of multiple dates. This is particularly useful for baskets, ETFs and dynamic indices, which can show their value at any future date or dates. For example, this will make it easy to write an Asian option, or any more exotic product, on a dynamic index underlying.

Incidentally, fix an issue with time-bumped pricing, when the instrument(s) is affected by the bump. Previously was not applying any bump to the model