### PR TITLE
Recursion for instruments, for example Basket

### DIFF
--- a/src/dates/datetime.rs
+++ b/src/dates/datetime.rs
@@ -18,7 +18,7 @@ use std::fmt;
 /// We do assume an ordering of the enums here, matching the order they are
 /// expressed. If other values are added, such as LiborFixingTime, we may
 /// need to implement comparison functions manually, using Ord and PartialOrd.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum TimeOfDay {
     Open,
     EDSP,
@@ -37,7 +37,7 @@ impl Display for TimeOfDay {
 
 /// Convenience struct that groups a date and a time of day. For example, this
 /// represents the time of a fixing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DateTime {
     date: Date,
     time_of_day: TimeOfDay

--- a/src/instruments/assets.rs
+++ b/src/instruments/assets.rs
@@ -342,7 +342,7 @@ impl Priceable for CreditEntity {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use math::numerics::approx_eq;
     use math::interpolation::Extrap;
@@ -356,17 +356,16 @@ mod tests {
     use data::forward::DriftlessForward;
     use std::rc::Rc;
 
-    fn sample_currency(step: u32) -> Currency {
+    pub fn sample_currency(step: u32) -> Currency {
         let calendar = Rc::new(WeekdayCalendar::new());
         let settlement = Rc::new(BusinessDays::new_step(calendar, step));
         Currency::new("GBP", settlement)
     }
 
-    fn sample_equity(currency: Rc<Currency>,
-        step: u32) -> Equity {
+    pub fn sample_equity(currency: Rc<Currency>, name: &str, step: u32) -> Equity {
         let calendar = Rc::new(WeekdayCalendar::new());
         let settlement = Rc::new(BusinessDays::new_step(calendar, step));
-        Equity::new("BP.L", "LSE", currency, settlement)
+        Equity::new(name, "LSE", currency, settlement)
     }
 
     struct SamplePricingContext { 
@@ -398,8 +397,9 @@ mod tests {
             Ok(Rc::new(DriftlessForward::new(self.spot)))
         }
 
-        fn vol_surface(&self, _instrument: &Instrument, _forward: Rc<Forward>,
-            _high_water_mark: Date) -> Result<Rc<VolSurface>, qm::Error> {
+        fn vol_surface(&self, _instrument: &Instrument, _high_water_mark: Date,
+            _forward_fn: &Fn() -> Result<Rc<Forward>, qm::Error>)
+            -> Result<Rc<VolSurface>, qm::Error> {
             Err(qm::Error::new("unsupported"))
         }
 
@@ -417,7 +417,7 @@ mod tests {
     fn test_equity_price_on_spot() {
         let spot = 123.4;
         let currency = Rc::new(sample_currency(2));
-        let equity = sample_equity(currency, 2);
+        let equity = sample_equity(currency, "BP.L", 2);
         let context = sample_pricing_context(spot);
         let val_date = DateTime::new(context.spot_date(), TimeOfDay::Open);
         let price = equity.price(&context, val_date).unwrap();
@@ -437,7 +437,7 @@ mod tests {
     fn test_equity_price_mismatching_dates() {
         let spot = 123.4;
         let currency = Rc::new(sample_currency(3));
-        let equity = sample_equity(currency, 3);
+        let equity = sample_equity(currency, "BP.L", 3);
         let context = sample_pricing_context(spot);
         let val_date = DateTime::new(context.spot_date() + 3, TimeOfDay::Open);
         let price = equity.price(&context, val_date).unwrap();

--- a/src/instruments/basket.rs
+++ b/src/instruments/basket.rs
@@ -1,0 +1,256 @@
+use instruments::fix_all;
+use std::rc::Rc;
+use std::fmt::Display;
+use std::fmt;
+use std::cmp::Ordering;
+use std::hash::Hash;
+use std::hash::Hasher;
+use instruments::Instrument;
+use instruments::Priceable;
+use instruments::PricingContext;
+use instruments::DependencyContext;
+use instruments::SpotRequirement;
+use instruments::assets::Currency;
+use dates::rules::DateRule;
+use dates::datetime::TimeOfDay;
+use dates::datetime::DateTime;
+use dates::datetime::DateDayFraction;
+use data::fixings::FixingTable;
+use core::qm;
+
+/// A basket of instruments, such as equities or composites. This uses
+/// the composite pattern (see Gang of Four Design Patterns).
+
+#[derive(Clone)]
+pub struct Basket {
+    id: String,
+    credit_id: String,
+    currency: Rc<Currency>,
+    settlement: Rc<DateRule>,
+    basket: Vec<(f64, Rc<Instrument>)>
+}
+
+impl Basket {
+    pub fn new(id: &str, credit_id: &str, currency: Rc<Currency>, 
+        settlement: Rc<DateRule>, basket: Vec<(f64, Rc<Instrument>)>)
+        -> Result<Basket, qm::Error> {
+
+        // validate that the basket members are all in the right currency
+
+        Ok(Basket { id: id.to_string(), credit_id: credit_id.to_string(),
+            currency: currency, settlement: settlement , basket: basket })
+    }
+}
+
+impl Instrument for Basket {
+    fn id(&self) -> &str { &self.id }
+    fn payoff_currency(&self) -> &Currency { &*self.currency }
+    fn credit_id(&self) -> &str { &self.credit_id }
+    fn settlement(&self) -> &Rc<DateRule> { &self.settlement }
+
+    fn dependencies(&self, context: &mut DependencyContext)
+        -> SpotRequirement {
+        for &(_, ref underlying) in self.basket.iter() {
+            let spot_requirement = underlying.dependencies(context);
+            match spot_requirement {
+                SpotRequirement::NotRequired => {}, // nothing to do
+                _ => context.spot(&underlying)
+            };
+        }
+        SpotRequirement::NotRequired
+    }
+
+    fn time_to_day_fraction(&self, date_time: DateTime)
+        -> Result<DateDayFraction, qm::Error> {
+
+        // for now, we hard-code the conversion. Later we shall
+        // allow this to be set per equity
+        let day_fraction = match date_time.time_of_day() {
+            TimeOfDay::Open => 0.0,
+            TimeOfDay::EDSP => 0.0,
+            TimeOfDay::Close => 0.8 };
+        Ok(DateDayFraction::new(date_time.date(), day_fraction))
+    }
+
+    fn as_priceable(&self) -> Option<&Priceable> {
+        Some(self)
+    }
+
+    fn fix(&self, fixing_table: &FixingTable)
+        -> Result<Option<Vec<(f64, Rc<Instrument>)>>, qm::Error> {
+        
+        match fix_all(&self.basket, fixing_table)? {
+            Some(basket) => {
+                let id = format!("{}:fixed", self.id());
+                let replacement : Rc<Instrument> = Rc::new(
+                    Basket::new(&id, self.credit_id(), self.currency.clone(), self.settlement().clone(), basket)?);
+                Ok(Some(vec![(1.0, replacement)]))
+            },
+            None => Ok(None)
+        }
+    }
+}
+
+impl Display for Basket {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.id.fmt(f)
+    }
+}
+
+impl Ord for Basket {
+    fn cmp(&self, other: &Basket) -> Ordering {
+        self.id.cmp(&other.id)
+    }
+}
+
+impl PartialOrd for Basket {
+    fn partial_cmp(&self, other: &Basket) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}   
+    
+impl PartialEq for Basket {
+    fn eq(&self, other: &Basket) -> bool {
+        self.id == other.id
+    }
+}
+
+impl Eq for Basket {} 
+
+impl Hash for Basket {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+impl Priceable for Basket {
+    fn as_instrument(&self) -> &Instrument { self }
+
+    /// The price of a basket is the weighted sum of the components.
+    fn prices(&self, context: &PricingContext, dates: &[DateTime], out: &mut [f64])
+        -> Result<(), qm::Error> {
+        let n_dates = dates.len();
+        assert_eq!(dates.len(), out.len());
+
+        for o in out.iter_mut() {
+            *o = 0.0;
+        }
+
+        let mut temp = vec!(0.0; n_dates);
+
+        for &(weight, ref underlying) in self.basket.iter() {
+            let priceable = underlying.as_priceable().ok_or_else(|| qm::Error::new(
+                "The underlying of an basket must be priceable"))?;
+            priceable.prices(context, dates, &mut temp)?;
+            for (i, o) in temp.iter().zip(out.iter_mut()) {
+                *o += i * weight;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use math::numerics::approx_eq;
+    use math::interpolation::Extrap;
+    use data::forward::Forward;
+    use data::volsurface::VolSurface;
+    use data::curves::RateCurveAct365;
+    use data::curves::RateCurve;
+    use dates::Date;
+    use data::forward::EquityForward;
+    use data::curves::ZeroRateCurve;
+    use data::divstream::DividendStream;
+    use std::rc::Rc;
+    use instruments::assets::tests::sample_currency;
+    use instruments::assets::tests::sample_equity;
+
+    pub fn sample_basket(step: u32) -> Basket {
+        let currency = Rc::new(sample_currency(step));
+        let az : Rc<Instrument> = Rc::new(sample_equity(currency.clone(), "AZ.L", step));
+        let bp : Rc<Instrument> = Rc::new(sample_equity(currency.clone(), "BP.L", step));
+        let basket = vec![(0.4, az.clone()), (0.6, bp.clone())];
+        Basket::new("basket", az.credit_id(), currency, az.settlement().clone(), basket).unwrap()
+    }
+
+    struct SamplePricingContext { 
+        spot_az: f64,
+        spot_bp: f64
+    }
+
+    impl PricingContext for SamplePricingContext {
+        fn spot_date(&self) -> Date {
+            Date::from_ymd(2018, 06, 01)
+        }
+
+        fn yield_curve(&self, _credit_id: &str,
+            _high_water_mark: Date) -> Result<Rc<RateCurve>, qm::Error> {
+
+            let d = Date::from_ymd(2018, 05, 30);
+            let points = [(d, 0.05), (d + 14, 0.08), (d + 56, 0.09),
+                (d + 112, 0.085), (d + 224, 0.082)];
+            let c = RateCurveAct365::new(d, &points,
+                Extrap::Flat, Extrap::Flat)?;
+            Ok(Rc::new(c))
+        }
+
+        fn spot(&self, id: &str) -> Result<f64, qm::Error> {
+            if id == "AZ.L" {
+                Ok(self.spot_az)
+            } else if id == "BP.L" {
+                Ok(self.spot_bp)
+            } else {
+                Err(qm::Error::new(&format!("{} not recognised for spot", id)))
+            }
+        }
+
+        fn forward_curve(&self, instrument: &Instrument, 
+            high_water_mark: Date) -> Result<Rc<Forward>, qm::Error> {
+            let spot = self.spot(instrument.id())?;
+            let base_date = self.spot_date();
+            let settlement = instrument.settlement().clone();
+            let rate = self.yield_curve(instrument.credit_id(), high_water_mark)?;
+            let borrow = Rc::new(ZeroRateCurve::new(base_date));
+            let divs = DividendStream::new(&Vec::new(), Rc::new(ZeroRateCurve::new(base_date)));
+            let forward = EquityForward::new(
+                base_date, spot, settlement, rate, borrow, &divs, high_water_mark)?;
+            Ok(Rc::new(forward))
+        }
+
+        fn vol_surface(&self, _instrument: &Instrument, _high_water_mark: Date,
+            _forward_fn: &Fn() -> Result<Rc<Forward>, qm::Error>)
+            -> Result<Rc<VolSurface>, qm::Error> {
+            Err(qm::Error::new("unsupported"))
+        }
+
+        fn correlation(&self, _first: &Instrument, _second: &Instrument)
+            -> Result<f64, qm::Error> {
+            Err(qm::Error::new("unsupported"))
+        }
+    }
+
+    fn sample_pricing_context(spot_az: f64, spot_bp: f64) -> SamplePricingContext {
+        SamplePricingContext { spot_az, spot_bp }
+    }
+
+    #[test]
+    fn test_basket() {
+
+        let context = sample_pricing_context(120.0, 230.0);
+        let basket = sample_basket(2);
+        let date = context.spot_date();
+        let price = basket.price(&context, DateTime::new(date, TimeOfDay::Close)).unwrap();
+        assert_approx(price, 120.0 * 0.4 + 230.0 * 0.6);
+
+        let forward = basket.price(&context, DateTime::new(date + 365, TimeOfDay::Close)).unwrap();
+        assert_approx(forward, 201.95832229014877);
+    }
+
+    fn assert_approx(value: f64, expected: f64) {
+        assert!(approx_eq(value, expected, 1e-12),
+            "value={} expected={}", value, expected);
+    }
+}

--- a/src/instruments/bonds.rs
+++ b/src/instruments/bonds.rs
@@ -183,8 +183,9 @@ mod tests {
             Err(qm::Error::new("Forward not supported"))
         }
 
-        fn vol_surface(&self, _instrument: &Instrument, _forward: Rc<Forward>,
-            _high_water_mark: Date) -> Result<Rc<VolSurface>, qm::Error> {
+        fn vol_surface(&self, _instrument: &Instrument, _high_water_mark: Date,
+            _forward_fn: &Fn() -> Result<Rc<Forward>, qm::Error>)
+            -> Result<Rc<VolSurface>, qm::Error> {
             Err(qm::Error::new("VolSurface not supported"))
         }
 

--- a/src/models/blackdiffusion.rs
+++ b/src/models/blackdiffusion.rs
@@ -254,7 +254,7 @@ pub fn calculate_substepping(
 
         let instr = instrument.instrument();
         let fwd = context.forward_curve(instr, hwm)?;
-        let surface = context.vol_surface(instr, fwd.clone(), hwm)?;
+        let surface = context.vol_surface(instr, hwm, &|| Ok(fwd.clone()))?;
 
         let mut prev_var = 0.0;
 
@@ -405,9 +405,8 @@ pub fn fetch_path(instrument: &Instrument, context: &PricingContext,
     // Fetch the market data we need
     let hwm = observations.last().unwrap().date();
     let forward_curve = context.forward_curve(instrument, hwm)?;
-    let vol_surface = context.vol_surface(instrument, forward_curve.clone(),
-        hwm)?;
-
+    let vol_surface = context.vol_surface(instrument, hwm, &|| Ok(forward_curve.clone()))?;
+    
     // Fetch the forwards and variances on each observation date
     // We use the at the forward variances, using the live forward curve
     // (consider optionally using the forwards in the vol surface).

--- a/src/pricers/selfpricer.rs
+++ b/src/pricers/selfpricer.rs
@@ -263,7 +263,7 @@ mod tests {
         let mut pricer = factory.new(instrument, fixings, market_data).unwrap();
 
         let unbumped_price = pricer.price().unwrap();
-        assert_approx(unbumped_price, 19.072086263185145, 1e-12);
+        assert_approx(unbumped_price, 19.059001770739144, 1e-12);
 
         // delta bump. We expect this delta to be fairly small, as it only comes from
         // the skew.
@@ -272,17 +272,17 @@ mod tests {
         let bumped = pricer.as_mut_bumpable().bump(&bump, Some(&mut *save)).unwrap();
         assert!(bumped);
         let bumped_price = pricer.price().unwrap();
-        assert_approx(bumped_price - unbumped_price, 0.20527149956129875, 1e-12);
+        assert_approx(bumped_price - unbumped_price, 0.20514185426620202, 1e-12);
         pricer.as_mut_bumpable().restore(&*save).unwrap();
         save.clear();
 
-        // bump past the strike date. Should result in a small negative theta.
+        // bump past the strike date. Should result in a small theta.
         let spot_date = Date::from_ymd(2017, 01, 02);
         let dynamics = SpotDynamics::StickyForward;
         let time_bump = BumpTime::new(spot_date + 1, spot_date, dynamics);
         pricer.as_mut_time_bumpable().bump_time(&time_bump).unwrap();
         let bumped_price = pricer.price().unwrap();
-        assert_approx(bumped_price - unbumped_price, -0.012516292441407728, 1e-12);
+        assert_approx(bumped_price - unbumped_price, 0.0005682000045936775, 1e-12);
 
         // again test the delta -- should now be much larger
         let bumped = pricer.as_mut_bumpable().bump(&bump, Some(&mut *save)).unwrap();

--- a/src/risk/bumptime.rs
+++ b/src/risk/bumptime.rs
@@ -87,12 +87,15 @@ impl BumpTime {
         }
 
         // Apply the fixings to each of the instruments, and build up a new vector of them
-        let any_changes = !fixing_map.is_empty();
+        let mut any_changes = !fixing_map.is_empty();
         if any_changes {
             let fixing_table = FixingTable::from_map(new_spot_date, &fixing_map)?;
-            let mut replacement = fix_all(instruments, &fixing_table)?;
-            instruments.clear();
-            instruments.append(&mut replacement);
+            if let Some(ref mut replacement) = fix_all(instruments, &fixing_table)? {
+                instruments.clear();
+                instruments.append(replacement);
+            } else {
+                any_changes = false;
+            }
         }
 
         Ok(any_changes)


### PR DESCRIPTION
Implement Basket using the composite pattern. Modify vanilla options so their underlier can be any instrument that is priceable, for example a Basket. Test europeans on baskets (with the vol surface at the basket level, so we can use standard Black Scholes).