### PR TITLE
Serialization and deserialization

### DIFF
--- a/src/core/factories.rs
+++ b/src/core/factories.rs
@@ -1,0 +1,377 @@
+//! Technology for registering factories of types and recognising
+//! the types.
+
+use std::rc::Rc;
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::fmt;
+use std::ops::Deref;
+use serde as sd;
+use erased_serde as esd;
+use serde_tagged::de::SeedFactory;
+use serde_tagged::util::TagString;
+use serde_tagged as sdt;
+use serde_tagged::util::erased::SerializeErased;
+
+/// Uniquely identify the type of an object
+pub trait TypeId {
+    fn type_id(&self) -> &'static str;
+}
+
+/// A registry of methods to deserialize objects given a tag to identify
+/// the type of object, using TypeId.
+pub struct Registry<V> {
+    registry: HashMap<&'static str, V>
+}
+
+impl<V> Registry<V> {
+
+    /// Creates an empty registry
+    pub fn new() -> Registry<V> {
+        Registry { registry: HashMap::new() }
+    }
+
+    /// Adds a creation method to the registry
+    pub fn insert(&mut self, key: &'static str, value: V) {
+        self.registry.insert(key, value);
+    }
+
+}
+
+// Allow use of the registration as a seed factor, for deserialization
+impl<'r, 'de, V, S> SeedFactory<'de, TagString<'de>> for &'r Registry<S>
+where
+    &'r S: sd::de::DeserializeSeed<'de, Value = V>
+{
+    type Value = V;
+    type Seed = &'r S;
+
+    fn seed<E>(self, tag: TagString<'de>) -> Result<Self::Seed, E>
+    where
+        E: sd::de::Error,
+    {
+        self.registry.get(tag.as_ref())
+            .ok_or_else(|| sd::de::Error::custom("Unknown tag"))
+    }
+}
+
+/// A source of a registry
+pub trait RegistrySource<T> {
+    fn get_registry() -> &'static Registry<T>;
+}
+
+/// Our own reference counted type, so we can implement serialization and
+/// deserialization.
+pub struct Qrc<T: esd::Serialize + TypeId + Debug + ?Sized>(Rc<T>);
+
+impl<T> Clone for Qrc<T>
+where T: esd::Serialize + TypeId + Debug + ?Sized {
+    fn clone(&self) -> Qrc<T> {
+        Qrc::new(self.0.clone())
+    }
+}
+
+impl<T> Deref for Qrc<T> 
+where T: esd::Serialize + TypeId + Debug + ?Sized {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T> Qrc<T> 
+where T: esd::Serialize + TypeId + Debug + ?Sized {
+    pub fn new(stored: Rc<T>) -> Qrc<T> {
+        Qrc(stored)
+    }
+}
+
+impl<T> TypeId for Qrc<T> 
+where T: esd::Serialize + TypeId + Debug + ?Sized {
+    fn type_id(&self) -> &'static str {
+        self.0.type_id()
+    }
+}
+
+impl<T> Debug for Qrc<T> 
+where T: esd::Serialize + TypeId + Debug + ?Sized {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<T> sd::Serialize for Qrc<T> 
+where T: esd::Serialize + TypeId + Debug + ?Sized {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: sd::Serializer,
+    {
+        // As tag we simply use the ID provided by our `TypeId` trait.
+        // To serialize our trait object value (without the tag) we actually
+        // need to call `erased_serde::serialize`. We can do this by wrapping
+        // the object in `SerializeErased`.
+        // The `serialize` method of `serde_erased::ser::external` will apply
+        // our type-id as tag to the trait-object.
+        sdt::ser::external::serialize(serializer, self.type_id(), &SerializeErased(&*self.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::rc::Rc;
+    use super::*;
+    use serde_json;
+    use serde;
+    use serde_tagged;
+    use serde_tagged::de::BoxFnSeed;
+
+    // An example for de-/serialization of trait objects.
+    // 
+    // Serializes trait-objects by enhancing the stored information with a tag,
+    // then later deserializes the stored tag, based on which a deserializer will
+    // be chosen for the value.
+    // 
+    // The data-structures in this example are straightforward, meaning that
+    // using an enum would probably make more sense here. However, enums can not
+    // be extended, e.g. by a user of your library, thus sometimes trait-objects
+    // are the only way.
+ 
+    // Let's begin by defining some data-types.
+
+    /// Our first type.
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+    pub struct A {
+        foo: String,
+    }
+
+    /// Our second type.
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
+    pub enum B {
+        Str(String),
+        Int(i64),
+    }
+
+    // You can use all de-/serializable data types in combination with this crate,
+    // we however will limit ourselves to these two for this example.
+
+    // We now need a way to identify our types.
+    // For this, we create a new trait. This trait returns a tag that will later be
+    // stored with our trait-object to describe its type.
+    // In general, the only requirements on the tag are that it implements
+    // `Serialize`. However since we are using the JSON format in combination with
+    // external tagging (and JSON only allows strings for object-keys), the tag
+    // must be a string.
+    // See TypeId definition above
+
+    // We also need to implement this trait for our types (and all types we want to
+    // de-/serialize as the same trait objects).
+
+    impl TypeId for A {
+        fn type_id(&self) -> &'static str {
+            "A"
+        }
+    }
+
+    impl TypeId for B {
+        fn type_id(&self) -> &'static str {
+            "B"
+        }
+    }
+
+    // Next we define the trait that we actually want to store as trait-object.
+    // this trait should require our `TypeId` trait, as well as all other traits
+    // that we want to be able to use on the trait object.
+
+    // One trait that is required for serialization and must be present on the
+    // trait-object to work is `erased_serde::Serialize`.
+    // Note that we can not use `serde::Serialize` due to it containing a generic
+    // method, however `erased_serde::Serialize` is automatically implemented for
+    // all types implementing `serde::Serialize`, so the only thing we have to do
+    // is add the trait bound here. No changes on our types are required.
+
+    // FYI: This is required to enforce a fixed v-table layout, which is required
+    //      to create a trait object from a set of traits.
+
+    /// The trait we actually want to store as trait object.
+    pub trait Stored: esd::Serialize + TypeId + Debug {}
+
+    // In this case, we also want to automatically implement it for all types which
+    // meet our requirements.
+    impl<T> Stored for T
+    where T: esd::Serialize + TypeId + Debug
+    {}
+
+    // Now we can implement `Serialize` and `Deserialize` for our trait objects.
+    // In this example we use external tagging, but you could also use any other
+    // strategy provided by this crate.
+
+    // WARNING:
+    // If we would serialize non-trait-objects (i.e. `Box<A>` or `Box<B>`), no
+    // tag will be emitted, as the `Serialize` implementation of `Box<A>`
+    // forwards to the `Serialize` implementation of `A`.
+    // Thus you should make sure that you always serialize a trait-object when
+    // you want to deserialize a trait object. To enforce this at compile time,
+    // you could implement a custom wrapper type.
+
+    impl<'a> serde::Serialize for Stored + 'a {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: serde::Serializer,
+        {
+            // As tag we simply use the ID provided by our `TypeId` trait.
+            // To serialize our trait object value (without the tag) we actually
+            // need to call `erased_serde::serialize`. We can do this by wrapping
+            // the object in `SerializeErased`.
+            // The `serialize` method of `serde_erased::ser::external` will apply
+            // our type-id as tag to the trait-object.
+            serde_tagged::ser::external::serialize(serializer, self.type_id(), &SerializeErased(self))
+        }
+    }
+
+    pub type RcStored = Qrc<Stored>;
+    pub type TypeRegistry = Registry<BoxFnSeed<RcStored>>;
+
+    /// Implement deserialization for subclasses of the type
+    impl<'de> sd::Deserialize<'de> for Qrc<Stored> {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: sd::Deserializer<'de>
+        {
+            sdt::de::external::deserialize(deserializer, get_registry())
+        }
+    }
+
+    /// Return the type registry required for deserialization.
+    pub fn get_registry() -> &'static TypeRegistry {
+        lazy_static! {
+            static ref REG: TypeRegistry = {
+                let mut reg = TypeRegistry::new();
+                reg.insert("A", BoxFnSeed::new(deserialize_erased::a));
+                reg.insert("B", BoxFnSeed::new(deserialize_erased::b));
+                reg
+            };
+        }
+        &REG
+    }
+
+    // Due to the complexity of the function signature, we need to implement our
+    // deserialization functions as actual functions. `rustc` will complain about
+    // lifetime-issues (for the `Deserializer`) if we use closures.
+    mod deserialize_erased {
+        use super::*;
+        use erased_serde::{Deserializer, Error};
+        use serde::Deserialize;
+
+        /// Deserialize a value of type `A` as trait-object.
+        pub fn a<'de>(de: &mut Deserializer<'de>) -> Result<RcStored, Error> {
+            Ok(RcStored::new(Rc::new(A::deserialize(de)?)))
+        }
+
+        /// Deserialize a value of type `B` as trait-object.
+        pub fn b<'de>(de: &mut Deserializer<'de>) -> Result<RcStored, Error> {
+            Ok(RcStored::new(Rc::new(B::deserialize(de)?)))
+        }
+    }
+
+    #[test]
+    fn serde_tagged_serialize() {
+
+        // Let's begin by creating our test data ...
+        let a : Rc<Stored> = Rc::new(A { foo: "bar".to_owned() });
+        let b : Rc<Stored> = Rc::new(B::Str("Hello World".to_owned()));
+        let c : Rc<Stored> = Rc::new(B::Int(42));
+
+        // ... and then transform it to trait objects.
+        // We use clone here so we can later assert that de-/serialization does not
+        // change anything.
+        let rc_a = RcStored::new(a.clone());
+        let rc_b = RcStored::new(b.clone());
+        let rc_c = RcStored::new(c.clone());
+ 
+        // Now we can serialize our trait-objects.
+        // Thanks to our `Serialize` implementation for trait objects this works
+        // just like with any other type.
+        let ser_a = serde_json::to_string_pretty(&rc_a).unwrap();
+        let ser_b = serde_json::to_string_pretty(&rc_b).unwrap();
+        let ser_c = serde_json::to_string_pretty(&rc_c).unwrap();
+
+        // Again note the warning regarding serialization of non-trait-objects
+        // above.
+
+        // We specified external tagging, so we expect the following:
+        assert_json_equal(&ser_a, r###"
+        {
+            "A": {
+                "foo": "bar"
+            }
+        }
+        "###);
+
+        assert_json_equal(&ser_b, r###"
+        {
+            "B": {
+                "Str": "Hello World"
+            }
+        }
+        "###);
+
+        assert_json_equal(&ser_c, r###"
+        {
+            "B": {
+                "Int": 42
+            }
+        }
+        "###);
+    }
+
+    #[test]
+    fn serde_tagged_roundtrip() {
+
+        // Let's begin by creating our test data ...
+        let a : Rc<Stored> = Rc::new(A { foo: "bar".to_owned() });
+        let b : Rc<Stored> = Rc::new(B::Str("Hello World".to_owned()));
+        let c : Rc<Stored> = Rc::new(B::Int(42));
+
+        // ... and then transform it to trait objects.
+        // We use clone here so we can later assert that de-/serialization does not
+        // change anything.
+        let rc_a = RcStored::new(a.clone());
+        let rc_b = RcStored::new(b.clone());
+        let rc_c = RcStored::new(c.clone());
+ 
+        // Now we can serialize our trait-objects.
+        // Thanks to our `Serialize` implementation for trait objects this works
+        // just like with any other type.
+        let ser_a = serde_json::to_string_pretty(&rc_a).unwrap();
+        let ser_b = serde_json::to_string_pretty(&rc_b).unwrap();
+        let ser_c = serde_json::to_string_pretty(&rc_c).unwrap();
+
+        // Again note the warning regarding serialization of non-trait-objects
+        // above.
+
+        // Now we let's deserialize our trait objects.
+        // This works also just like any other type.
+        let de_a: RcStored = serde_json::from_str(&ser_a).unwrap();
+        let de_b: RcStored = serde_json::from_str(&ser_b).unwrap();
+        let de_c: RcStored = serde_json::from_str(&ser_c).unwrap();
+
+        assert_debug_eq(&rc_a, &de_a);
+        assert_debug_eq(&rc_b, &de_b);
+        assert_debug_eq(&rc_c, &de_c);
+    }
+
+    /// A helper function to assert that two strings contain the same JSON data.
+    fn assert_json_equal(a: &str, b: &str) {
+        let a: serde_json::Value = serde_json::from_str(a).unwrap();
+        let b: serde_json::Value = serde_json::from_str(b).unwrap();
+        assert_eq!(a, b);
+    }
+
+    /// A helper function to assert that the debug representations of two objects
+    /// are the same
+    fn assert_debug_eq(a: &RcStored, b: &RcStored) {
+        let a_debug = format!("{:?}", a);
+        let b_debug = format!("{:?}", b);
+        assert_eq!(a_debug, b_debug);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,1 +1,2 @@
 pub mod qm;
+pub mod factories;

--- a/src/data/bumpyield.rs
+++ b/src/data/bumpyield.rs
@@ -1,8 +1,8 @@
 use std::rc::Rc;
-use data::curves::RateCurve;
 use data::curves::AnnualisedFlatBump;
 use data::curves::ContinuouslyCompoundedFlatBump;
 use data::bump::Bumper;
+use data::curves::RcRateCurve;
 
 /// Bump that defines all the supported bumps and risk transformations of a
 /// rate curve such as a borrow curve or a yield curve.
@@ -21,20 +21,20 @@ impl BumpYield {
     }
 }
 
-impl Bumper<Rc<RateCurve>> for BumpYield {
+impl Bumper<RcRateCurve> for BumpYield {
 
-    fn apply(&self, surface: Rc<RateCurve>) -> Rc<RateCurve> {
+    fn apply(&self, surface: RcRateCurve) -> RcRateCurve {
         match self {
             &BumpYield::FlatAnnualised { size }
-                => Rc::new(AnnualisedFlatBump::new(
-                    surface.clone(), size)),
+                => RcRateCurve::new(Rc::new(AnnualisedFlatBump::new(
+                    surface.clone(), size))),
 
             // Note that an alternative methodology here would be to
             // bump the pillars. Consider this if profiling shows this
             // to be a bottleneck.
             &BumpYield::FlatContinuouslyCompounded { size }
-                => Rc::new(ContinuouslyCompoundedFlatBump::new(
-                    surface.clone(), size))
+                => RcRateCurve::new(Rc::new(ContinuouslyCompoundedFlatBump::new(
+                    surface.clone(), size)))
         }
     }
 }

--- a/src/data/forward.rs
+++ b/src/data/forward.rs
@@ -3,6 +3,7 @@ use dates::rules::DateRule;
 use math::interpolation::Interpolate;
 use data::divstream::DividendBootstrap;
 use data::divstream::DividendStream;
+use data::curves::RcRateCurve;
 use data::curves::RateCurve;
 use core::qm;
 use std::rc::Rc;
@@ -67,9 +68,9 @@ impl InterpolatedForward {
 /// borrow, defines the rate of growth, plus a dividend stream.
 pub struct EquityForward {
     settlement: Rc<DateRule>,
-    rate: Rc<RateCurve>,
-    borrow: Rc<RateCurve>,
-    div_yield: Rc<RateCurve>,
+    rate: RcRateCurve,
+    borrow: RcRateCurve,
+    div_yield: RcRateCurve,
     bootstrap: DividendBootstrap,
     reference_spot: f64,
     base_log_discount: f64
@@ -104,8 +105,8 @@ impl EquityForward {
         base_date: Date,
         spot: f64,
         settlement: Rc<DateRule>,
-        rate: Rc<RateCurve>,
-        borrow: Rc<RateCurve>,
+        rate: RcRateCurve,
+        borrow: RcRateCurve,
         divs: &DividendStream,
         high_water_mark: Date) -> Result<EquityForward, qm::Error> {
 
@@ -252,25 +253,25 @@ mod tests {
             (d + 365 * 5, 0.01), (d + 365 * 10, 0.015)];
         let curve = RateCurveAct365::new(d + 365 * 2, &points,
             Extrap::Zero, Extrap::Flat).unwrap();
-        let div_yield = Rc::new(curve);
+        let div_yield = RcRateCurve::new(Rc::new(curve));
 
         DividendStream::new(&divs, div_yield)
     }
 
-    fn create_sample_rate() -> Rc<RateCurve> {
+    fn create_sample_rate() -> RcRateCurve {
         let d = Date::from_ymd(2016, 12, 30);
         let rate_points = [(d, 0.05), (d + 14, 0.08), (d + 182, 0.09),
             (d + 364, 0.085), (d + 728, 0.082)];
-        Rc::new(RateCurveAct365::new(d, &rate_points,
-            Extrap::Flat, Extrap::Flat).unwrap())
+        RcRateCurve::new(Rc::new(RateCurveAct365::new(d, &rate_points,
+            Extrap::Flat, Extrap::Flat).unwrap()))
     }
 
-    fn create_sample_borrow() -> Rc<RateCurve> {
+    fn create_sample_borrow() -> RcRateCurve {
         let d = Date::from_ymd(2016, 12, 30);
         let borrow_points = [(d, 0.01), (d + 196, 0.012),
             (d + 364, 0.0125), (d + 728, 0.012)];
-        Rc::new(RateCurveAct365::new(d, &borrow_points,
-            Extrap::Flat, Extrap::Flat).unwrap())
+        RcRateCurve::new(Rc::new(RateCurveAct365::new(d, &borrow_points,
+            Extrap::Flat, Extrap::Flat).unwrap()))
     }
 
     fn assert_match(result: Result<f64, qm::Error>, expected: f64) {

--- a/src/data/volsurface.rs
+++ b/src/data/volsurface.rs
@@ -354,6 +354,7 @@ impl VolForwardDynamics {
 }
 
 /// Flat volatility surface. Volatility is independent of date and strike.
+//#[derive(Clone, Serialize, Deserialize)]
 pub struct FlatVolSurface {
     vol: f64,
     calendar: Rc<Calendar>,

--- a/src/dates/calendar.rs
+++ b/src/dates/calendar.rs
@@ -72,6 +72,7 @@ pub trait Calendar {
 
 /// An every-day calendar assumes that all days are business days, including
 /// weekends.
+#[derive(Serialize, Deserialize)]
 pub struct EveryDayCalendar();
 
 impl Calendar for EveryDayCalendar {
@@ -112,6 +113,7 @@ impl Calendar for EveryDayCalendar {
 
 /// A weekday calendar assumes that Monday to Friday are business days, and
 /// Saturday and Sunday are not.
+#[derive(Serialize, Deserialize)]
 pub struct WeekdayCalendar();
 
 impl WeekdayCalendar {
@@ -224,10 +226,11 @@ fn slip_to_next_weekday(from: Date, slip_forward: bool) -> Date {
 /// A calendar that assumes that Saturday and Sunday are not business days,
 /// together with a specified list of business holidays. In general this list
 /// is read from a file.
+#[derive(Serialize, Deserialize)]
 pub struct WeekdayAndHolidayCalendar {
     name: String,
     holidays: Vec<Date>		// must be in date order, with no duplicates
-                                // and no weekend dates
+                            // and no weekend dates
 }
 
 impl WeekdayAndHolidayCalendar {
@@ -405,6 +408,7 @@ impl Calendar for WeekdayAndHolidayCalendar {
 /// corresponding spot model, and this is achieved by calling the step
 /// function. We may end up trying to roll by non-integer numbers of days.
 /// In that case, we round to the nearest integer.
+//#[derive(Serialize, Deserialize)]
 pub struct VolatilityCalendar {
     name: String,
     calendar: Box<Calendar>,

--- a/src/instruments/assets.rs
+++ b/src/instruments/assets.rs
@@ -349,7 +349,7 @@ pub mod tests {
     use data::forward::Forward;
     use data::volsurface::VolSurface;
     use data::curves::RateCurveAct365;
-    use data::curves::RateCurve;
+    use data::curves::RcRateCurve;
     use dates::calendar::WeekdayCalendar;
     use dates::rules::BusinessDays;
     use dates::Date;
@@ -378,14 +378,14 @@ pub mod tests {
         }
 
         fn yield_curve(&self, _credit_id: &str,
-            _high_water_mark: Date) -> Result<Rc<RateCurve>, qm::Error> {
+            _high_water_mark: Date) -> Result<RcRateCurve, qm::Error> {
 
             let d = Date::from_ymd(2018, 05, 30);
             let points = [(d, 0.05), (d + 14, 0.08), (d + 56, 0.09),
                 (d + 112, 0.085), (d + 224, 0.082)];
             let c = RateCurveAct365::new(d, &points,
                 Extrap::Flat, Extrap::Flat)?;
-            Ok(Rc::new(c))
+            Ok(RcRateCurve::new(Rc::new(c)))
         }
 
         fn spot(&self, _id: &str) -> Result<f64, qm::Error> {

--- a/src/instruments/basket.rs
+++ b/src/instruments/basket.rs
@@ -159,7 +159,7 @@ pub mod tests {
     use data::forward::Forward;
     use data::volsurface::VolSurface;
     use data::curves::RateCurveAct365;
-    use data::curves::RateCurve;
+    use data::curves::RcRateCurve;
     use dates::Date;
     use data::forward::EquityForward;
     use data::curves::ZeroRateCurve;
@@ -187,14 +187,14 @@ pub mod tests {
         }
 
         fn yield_curve(&self, _credit_id: &str,
-            _high_water_mark: Date) -> Result<Rc<RateCurve>, qm::Error> {
+            _high_water_mark: Date) -> Result<RcRateCurve, qm::Error> {
 
             let d = Date::from_ymd(2018, 05, 30);
             let points = [(d, 0.05), (d + 14, 0.08), (d + 56, 0.09),
                 (d + 112, 0.085), (d + 224, 0.082)];
             let c = RateCurveAct365::new(d, &points,
                 Extrap::Flat, Extrap::Flat)?;
-            Ok(Rc::new(c))
+            Ok(RcRateCurve::new(Rc::new(c)))
         }
 
         fn spot(&self, id: &str) -> Result<f64, qm::Error> {
@@ -213,8 +213,8 @@ pub mod tests {
             let base_date = self.spot_date();
             let settlement = instrument.settlement().clone();
             let rate = self.yield_curve(instrument.credit_id(), high_water_mark)?;
-            let borrow = Rc::new(ZeroRateCurve::new(base_date));
-            let divs = DividendStream::new(&Vec::new(), Rc::new(ZeroRateCurve::new(base_date)));
+            let borrow = RcRateCurve::new(Rc::new(ZeroRateCurve::new(base_date)));
+            let divs = DividendStream::new(&Vec::new(), RcRateCurve::new(Rc::new(ZeroRateCurve::new(base_date))));
             let forward = EquityForward::new(
                 base_date, spot, settlement, rate, borrow, &divs, high_water_mark)?;
             Ok(Rc::new(forward))

--- a/src/instruments/bonds.rs
+++ b/src/instruments/bonds.rs
@@ -133,7 +133,7 @@ mod tests {
     use math::numerics::approx_eq;
     use math::interpolation::Extrap;
     use data::curves::RateCurveAct365;
-    use data::curves::RateCurve;
+    use data::curves::RcRateCurve;
     use data::forward::Forward;
     use data::volsurface::VolSurface;
     use dates::calendar::WeekdayCalendar;
@@ -164,14 +164,14 @@ mod tests {
         }
 
         fn yield_curve(&self, _credit_id: &str,
-            _high_water_mark: Date) -> Result<Rc<RateCurve>, qm::Error> {
+            _high_water_mark: Date) -> Result<RcRateCurve, qm::Error> {
 
             let d = Date::from_ymd(2018, 05, 30);
             let points = [(d, 0.05), (d + 14, 0.08), (d + 56, 0.09),
                 (d + 112, 0.085), (d + 224, 0.082)];
             let c = RateCurveAct365::new(d, &points,
                 Extrap::Flat, Extrap::Flat)?;
-            Ok(Rc::new(c))
+            Ok(RcRateCurve::new(Rc::new(c)))
         }
 
         fn spot(&self, _id: &str) -> Result<f64, qm::Error> {

--- a/src/instruments/mod.rs
+++ b/src/instruments/mod.rs
@@ -9,7 +9,7 @@ use dates::Date;
 use dates::rules::DateRule;
 use dates::datetime::DateTime;
 use dates::datetime::DateDayFraction;
-use data::curves::RateCurve;
+use data::curves::RcRateCurve;
 use data::forward::Forward;
 use data::volsurface::VolSurface;
 use data::volsurface::VolTimeDynamics;
@@ -367,7 +367,7 @@ pub trait PricingContext {
 
     /// Gets a yield curve, given an instrument to define the discounting.
     fn yield_curve(&self, credit_id: &str, high_water_mark: Date)
-        -> Result<Rc<RateCurve>, qm::Error>;
+        -> Result<RcRateCurve, qm::Error>;
 
     /// Gets a spot value, given the id of any instrument
     fn spot(&self, id: &str) -> Result<f64, qm::Error>;

--- a/src/instruments/options.rs
+++ b/src/instruments/options.rs
@@ -573,7 +573,7 @@ mod tests {
     use data::forward::Forward;
     use data::volsurface::VolSurface;
     use data::curves::RateCurveAct365;
-    use data::curves::RateCurve;
+    use data::curves::RcRateCurve;
     use data::forward::InterpolatedForward;
     use data::volsurface::FlatVolSurface;
     use dates::calendar::WeekdayCalendar;
@@ -593,14 +593,14 @@ mod tests {
         }
 
         fn yield_curve(&self, _credit_id: &str, _high_water_mark: Date)
-                -> Result<Rc<RateCurve>, qm::Error> {
+                -> Result<RcRateCurve, qm::Error> {
 
             let d = Date::from_ymd(2018, 05, 30);
             let points = [(d, 0.05), (d + 14, 0.08), (d + 56, 0.09),
                 (d + 112, 0.085), (d + 224, 0.082)];
             let c = RateCurveAct365::new(d, &points,
                 Extrap::Flat, Extrap::Flat)?;
-            Ok(Rc::new(c))
+            Ok(RcRateCurve::new(Rc::new(c)))
         }
 
         fn spot(&self, id: &str) -> Result<f64, qm::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,15 @@ extern crate statrs;
 extern crate ndarray;
 extern crate nalgebra;
 extern crate rand;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde;
+extern crate erased_serde;
+extern crate serde_tagged;
+extern crate serde_json;
+#[macro_use]
+extern crate lazy_static;
+
 // listed in dependency order, though this is not essential for compilation
 pub mod core;
 pub mod math;

--- a/src/risk/cache.rs
+++ b/src/risk/cache.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::any::Any;
 use data::volsurface::VolSurface;
 use data::forward::Forward;
-use data::curves::RateCurve;
+use data::curves::RcRateCurve;
 use data::bump::Bump;
 use dates::Date;
 use instruments::Instrument;
@@ -172,7 +172,7 @@ impl PricingContext for PricingContextPrefetch {
     }
 
     fn yield_curve(&self, credit_id: &str, high_water_mark: Date)
-        -> Result<Rc<RateCurve>, qm::Error> {
+        -> Result<RcRateCurve, qm::Error> {
         // Currently there is no work in fetching a yield curve, so we do
         // not cache this. If yield curves were to be cooked internally, this
         // would change.


### PR DESCRIPTION
This commit starts with just serialization of rate curves and their components. We use serde for serializing/deserializing built-in types and concrete objects, and erased_serde and serde_tagged for serializing/deserializing polymorphic objects, such as rate curves themselves.