### PR TITLE
Implement deduplication for DAGs of shared objects

### DIFF
--- a/src/core/dedup.rs
+++ b/src/core/dedup.rs
@@ -1,0 +1,476 @@
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::sync::Arc;
+use std::cell::RefCell;
+use std::fmt;
+use std::fmt::Debug;
+use std::ops::Deref;
+use std::thread::LocalKey;
+use std::mem::swap;
+use std::marker::PhantomData;
+use std::marker::Sized;
+use serde as sd;
+use serde::ser::Error;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::de::Visitor;
+
+/// Technology to deduplicate directed acyclic graphs based on Rc pointers
+/// during serialization and deserialization.
+pub struct Dedup<T, R>
+where
+    T: InstanceId + sd::Serialize + Wrap<R> + Debug + ?Sized,
+    for<'de> T: sd::Deserialize<'de>,
+    R: Deref<Target = T> + Clone,
+    Drc<T, R>: FromId,
+{
+    control: DedupControl,
+    map: HashMap<String, Drc<T, R>>
+}
+
+impl<T, R> Dedup<T, R>
+where
+    T: InstanceId + sd::Serialize + Wrap<R> + Debug + ?Sized,
+    for<'de> T: sd::Deserialize<'de>,
+    R: Deref<Target = T> + Clone,
+    Drc<T, R>: FromId,
+{
+    pub fn new(control: DedupControl, map: HashMap<String, Drc<T, R>>) -> Self {
+        Dedup { control, map }
+    }
+   
+    /// Run the supplied closure in the context of this Dedup state
+    pub fn with<F, Q>(&mut self, tls_seed: &'static LocalKey<RefCell<Dedup<T, R>>>, f: F) -> Q 
+    where F: FnOnce() -> Q {
+
+        // store our state in a thread-local variable, as there is no other way of
+        // passing state through the serialize stack
+        tls_seed.with(|s| {
+            swap(&mut *s.borrow_mut(), self);
+        });
+
+        let result = f();
+
+        // by swapping in and out of our own member variables, we save the state of the
+        // thread-local variable, as well as providing our own state to the serialize
+        // functions
+        tls_seed.with(|s| {
+            swap(&mut *s.borrow_mut(), self);
+        });
+
+        result
+    }
+
+    pub fn control(&self) -> &DedupControl { &self.control }
+
+    /// Tries to insert the element into the map. If it was inserted, returns None, otherwise
+    /// returns the old value.
+    pub fn insert(&mut self, value: Drc<T, R>) -> Option<Drc<T, R>> {
+        self.map.insert(value.id().to_string(), value)
+    }
+
+    /// Finds an element given a string, or returns None if not found.
+    pub fn get(&self, id: &str) -> Option<Drc<T, R>> {
+        if let Some(element) = self.map.get(id) {
+            Some(element.clone())
+        } else {
+            None
+        }
+    }
+
+    /// Returns true if the map contains this key
+    pub fn contains_key(&self, id: &str) -> bool {
+        self.map.contains_key(id)
+    }
+}
+
+/// What to do when we are serializing or deserializing and we meet a DAG node
+#[derive(Clone, Copy, Debug)]
+pub enum DedupControl {
+    /// for deserializing or serializing with an expected set of components
+    ErrorIfMissing,
+    /// serialize with all components recursed inline
+    Inline,
+    /// when serializing, write once, then reuse
+    WriteOnce
+}
+
+/// Objects that can be deduplicated have to have a unique instance id
+pub trait InstanceId {
+    fn id(&self) -> &str;
+}
+
+/// Wrap a type T in a container R so it can be used in a Drp<T, R>.
+/// For example, R may be an Rc or Arc
+pub trait Wrap<R> {
+    fn wrap(self) -> R;
+}
+
+impl<T> Wrap<Rc<T>> for T {
+    fn wrap(self) -> Rc<T> {
+        Rc::new(self)
+    }
+}
+
+impl<T> Wrap<Arc<T>> for T {
+    fn wrap(self) -> Arc<T> {
+        Arc::new(self)
+    }
+}
+
+/// Edges in the graph must be contained in our own subclass of Rc, so we
+/// can implement our serialize/deserialize methods on it.
+pub struct Drc<T, R>(R)
+where
+    T: InstanceId + sd::Serialize + Wrap<R> + Debug + ?Sized,
+    for<'de> T: sd::Deserialize<'de>,
+    R: Deref<Target = T> + Clone,
+    Drc<T, R>: FromId;
+    
+impl<T, R> Drc<T, R> 
+where
+    T: InstanceId + sd::Serialize + Wrap<R> + Debug + ?Sized,
+    for<'de> T: sd::Deserialize<'de>,
+    R: Deref<Target = T> + Clone,
+    Drc<T, R>: FromId,
+{
+    pub fn new(value: R) -> Drc<T, R> {
+        Drc(value)
+    }
+
+    pub fn serialize_with_dedup<S>(&self, serializer: S,
+        tls_seed: &'static LocalKey<RefCell<Dedup<T, R>>>)
+        -> Result<S::Ok, S::Error>
+    where S: sd::Serializer {
+
+        let control = tls_seed.with(|tls| tls.borrow().control().clone());
+        match control {
+            // Inline serialization means we just recurse into the shared pointer. There is
+            // no deduplication.
+            DedupControl::Inline => self.0.serialize(serializer),
+
+            // ErrorIfMissing means all subcomponents should be supplied in the map
+            DedupControl::ErrorIfMissing => {
+                let id = self.0.id();
+                let has_key = tls_seed.with(|tls| tls.borrow().contains_key(id));
+                if !has_key {
+                    Err(S::Error::custom(&format!("Unknown id: {}", id)))
+                } else {
+                    serializer.serialize_str(id)
+                }
+            }
+
+            // WriteOnce means we look for the component in the map, and write it and insert it
+            // if it is not there
+            DedupControl::WriteOnce => {
+                let prev = tls_seed.with(|tls| tls.borrow_mut().insert(self.clone()));
+                if let None = prev {
+                    self.0.serialize(serializer)
+                } else {
+                    serializer.serialize_str(self.0.id())
+                }
+            }
+        }
+    }
+
+    pub fn deserialize_with_dedup<'de, D>(deserializer: D,
+        tls_seed: &'static LocalKey<RefCell<Dedup<T, R>>>) -> Result<Self, D::Error>
+    where D: sd::Deserializer<'de> {
+
+        let control = tls_seed.with(|tls| tls.borrow().control().clone());
+        match control {
+            // Inline deserialization means we assume the serial form contains the definition
+            // of the data inline. Simply recurse into it.
+            DedupControl::Inline => {
+                let obj = T::deserialize(deserializer)?;
+                Ok(Drc::new(obj.wrap()))
+            },
+
+            // ErrorIfMissing means all subcomponents should be supplied in the map. We should just
+            // be looking for a string.
+            DedupControl::ErrorIfMissing => {
+                string_or_struct::<T, R, D>(deserializer)
+            },
+
+            // WriteOnce means we look for the component in the map, and write it and insert it
+            // if it is not there
+            DedupControl::WriteOnce => {
+                let obj = string_or_struct::<T, R, D>(deserializer)?;
+                tls_seed.with(|tls| tls.borrow_mut().insert(obj.clone()));
+                Ok(obj)
+            }
+        }
+    }
+}
+
+impl<T, R> Clone for Drc<T, R>
+where
+    T: InstanceId + sd::Serialize + Wrap<R> + Debug + ?Sized,
+    for<'de> T: sd::Deserialize<'de>,
+    R: Deref<Target = T> + Clone,
+    Drc<T, R>: FromId,
+{
+    fn clone(&self) -> Self {
+        Drc::new(self.0.clone())
+    }
+}
+
+impl<T, R> Deref for Drc<T, R> 
+where
+    T: InstanceId + sd::Serialize + Wrap<R> + Debug + ?Sized,
+    for<'de> T: sd::Deserialize<'de>,
+    R: Deref<Target = T> + Clone,
+    Drc<T, R>: FromId,
+{
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T, R> Debug for Drc<T, R> 
+where
+    T: InstanceId + sd::Serialize + Wrap<R> + Debug + ?Sized,
+    for<'de> T: sd::Deserialize<'de>,
+    R: Deref<Target = T> + Clone,
+    Drc<T, R>: FromId,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Interface that fetches an instance of an object given its ID.
+pub trait FromId where Self: Sized {
+    fn from_id(id: &str) -> Option<Self>;
+}
+
+// Code based on the example 'string_or_struct' given in the serde documentation
+pub fn string_or_struct<'de, T, R, D>(deserializer: D) -> Result<Drc<T, R>, D::Error>
+where
+    T: InstanceId + sd::Serialize + Wrap<R> + Debug + ?Sized,
+    for<'de2> T: sd::Deserialize<'de2>,
+    R: Deref<Target = T> + Clone,
+    Drc<T, R>: FromId,
+    D: Deserializer<'de>,
+{
+    // This is a Visitor that forwards string types to T's `FromId` impl and
+    // forwards map types to T's `Deserialize` impl. The `PhantomData` is to
+    // keep the compiler from complaining about T being an unused generic type
+    // parameter. We need T in order to know the Value type for the Visitor
+    // impl.
+    struct StringOrStruct<T, R>(PhantomData<fn() -> (T, R)>);
+
+    impl<'de, T, R> Visitor<'de> for StringOrStruct<T, R>
+    where
+        T: InstanceId + sd::Serialize + Wrap<R> + Debug + ?Sized,
+        for<'de2> T: sd::Deserialize<'de2>,
+        R: Deref<Target = T> + Clone,
+        Drc<T, R>: FromId,
+    {
+        type Value = Drc<T, R>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("string or map")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Drc<T, R>, E>
+        where
+            E: sd::de::Error,
+        {
+            if let Some(result) = FromId::from_id(value) {
+                Ok(result)
+            } else {
+                Err(sd::de::Error::invalid_value(sd::de::Unexpected::Str(value), &self))
+            }
+        }
+
+        fn visit_map<M>(self, visitor: M) -> Result<Drc<T, R>, M::Error>
+        where
+            M: sd::de::MapAccess<'de>,
+        {
+            // `MapAccessDeserializer` is a wrapper that turns a `MapAccess`
+            // into a `Deserializer`, allowing it to be used as the input to T's
+            // `Deserialize` implementation. T then deserializes itself using
+            // the entries from the map visitor.
+            let obj: T = Deserialize::deserialize(sd::de::value::MapAccessDeserializer::new(visitor))?;
+            Ok(Drc::new(obj.wrap()))
+        }
+    }
+
+    deserializer.deserialize_any(StringOrStruct(PhantomData))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+    use serde::Deserialize;
+    use serde::Serialize;
+
+    /// an example node from a DAG (here a binary tree)
+    #[derive(Serialize, Deserialize, Debug)]
+    struct Node {
+        id: String,
+        data: i32,
+        left: Option<Drc<Node, Rc<Node>>>,
+        right: Option<Drc<Node, Rc<Node>>>
+    }
+
+    thread_local! {
+        static DEDUP_NODE : RefCell<Dedup<Node, Rc<Node>>> 
+            = RefCell::new(Dedup::new(DedupControl::Inline, HashMap::new()));
+    }
+
+    type DrcNode = Drc<Node, Rc<Node>>;
+
+    impl InstanceId for Node {
+        fn id(&self) -> &str { &self.id }
+    }
+
+    impl FromId for DrcNode {
+        fn from_id(id: &str) -> Option<Self> {
+            DEDUP_NODE.with(|tls| tls.borrow().get(id).clone())
+        }
+    }
+
+    impl sd::Serialize for DrcNode {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where S: sd::Serializer {
+            self.serialize_with_dedup(serializer, &DEDUP_NODE)
+        }
+    }
+
+    impl<'de> sd::Deserialize<'de> for DrcNode {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+        where D: sd::Deserializer<'de> {
+            Self::deserialize_with_dedup(deserializer, &DEDUP_NODE)
+        }
+    }
+
+    #[test]
+    fn serde_dedup_inline() {
+
+        test_dedup(DedupControl::Inline, HashMap::new(), r###"{
+  "id": "e",
+  "data": 4,
+  "left": {
+    "id": "c",
+    "data": 2,
+    "left": {
+      "id": "a",
+      "data": 0,
+      "left": null,
+      "right": null
+    },
+    "right": {
+      "id": "b",
+      "data": 1,
+      "left": null,
+      "right": null
+    }
+  },
+  "right": {
+    "id": "d",
+    "data": 3,
+    "left": {
+      "id": "a",
+      "data": 0,
+      "left": null,
+      "right": null
+    },
+    "right": {
+      "id": "b",
+      "data": 1,
+      "left": null,
+      "right": null
+    }
+  }
+}"###);
+    }
+
+    #[test]
+    fn serde_dedup_error_if_missing() {
+
+        let a = DrcNode::new(Rc::new(Node { id: "a".to_string(), data: 0, left: None, right: None }));
+        let b = DrcNode::new(Rc::new(Node { id: "b".to_string(), data: 1, left: None, right: None }));
+        let c = DrcNode::new(Rc::new(Node { id: "c".to_string(), data: 2, left: Some(a.clone()), right: Some(b.clone()) }));
+        let d = DrcNode::new(Rc::new(Node { id: "d".to_string(), data: 3, left: Some(a.clone()), right: Some(b.clone()) }));
+        
+        let mut map = HashMap::new();
+        map.insert("a".to_string(), a);
+        map.insert("b".to_string(), b);
+        map.insert("c".to_string(), c);
+        map.insert("d".to_string(), d);
+
+        test_dedup(DedupControl::ErrorIfMissing, map, r###"{
+  "id": "e",
+  "data": 4,
+  "left": "c",
+  "right": "d"
+}"###);
+    }
+
+    #[test]
+    fn serde_dedup_write_once() {
+        test_dedup(DedupControl::WriteOnce, HashMap::new(), r###"{
+  "id": "e",
+  "data": 4,
+  "left": {
+    "id": "c",
+    "data": 2,
+    "left": {
+      "id": "a",
+      "data": 0,
+      "left": null,
+      "right": null
+    },
+    "right": {
+      "id": "b",
+      "data": 1,
+      "left": null,
+      "right": null
+    }
+  },
+  "right": {
+    "id": "d",
+    "data": 3,
+    "left": "a",
+    "right": "b"
+  }
+}"###);
+    }
+
+    fn test_dedup(control: DedupControl, map: HashMap<String, DrcNode>, expected: &str) {
+
+        // create a sample graph
+        let a = DrcNode::new(Rc::new(Node { id: "a".to_string(), data: 0, left: None, right: None }));
+        let b = DrcNode::new(Rc::new(Node { id: "b".to_string(), data: 1, left: None, right: None }));
+        let c = DrcNode::new(Rc::new(Node { id: "c".to_string(), data: 2, left: Some(a.clone()), right: Some(b.clone()) }));
+        let d = DrcNode::new(Rc::new(Node { id: "d".to_string(), data: 3, left: Some(a.clone()), right: Some(b.clone()) }));
+        let e = Node { id: "e".to_string(), data: 4, left: Some(c.clone()), right: Some(d.clone()) };
+
+        // write it out and read it back in
+        let mut buffer = Vec::new();
+        {
+            let mut serializer = serde_json::Serializer::pretty(&mut buffer);
+            let mut seed = Dedup::<Node, Rc<Node>>::new(control.clone(), map.clone());
+            seed.with(&DEDUP_NODE, || e.serialize(&mut serializer)).unwrap();
+        }
+
+        let json = String::from_utf8(buffer.clone()).unwrap();
+        print!("{}", json);
+        assert_eq!(json, expected);
+
+        let deserialized = {
+            let mut deserializer = serde_json::Deserializer::from_slice(&buffer);
+            let mut seed = Dedup::<Node, Rc<Node>>::new(control.clone(), map.clone());
+            seed.with(&DEDUP_NODE, || DrcNode::deserialize(&mut deserializer)).unwrap()
+        };
+
+        let e_debug = format!("{:?}", e);
+        let deserialized_debug = format!("{:?}", deserialized);
+        assert_eq!(deserialized_debug, e_debug);
+    }
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,2 +1,3 @@
 pub mod qm;
 pub mod factories;
+pub mod dedup;

--- a/src/data/bumpdivs.rs
+++ b/src/data/bumpdivs.rs
@@ -1,6 +1,7 @@
-use std::rc::Rc;
+use data::divstream::RcDividendStream;
 use data::divstream::DividendStream;
 use data::bump::Bumper;
+use std::rc::Rc;
 
 /// Bump that defines all the supported bumps and risk transformations of a
 /// vol surface.
@@ -14,12 +15,12 @@ impl BumpDivs {
     }
 }
 
-impl Bumper<Rc<DividendStream>> for BumpDivs {
+impl Bumper<RcDividendStream> for BumpDivs {
 
-    fn apply(&self, divs: Rc<DividendStream>) -> Rc<DividendStream> {
+    fn apply(&self, divs: RcDividendStream) -> RcDividendStream {
         match self {
             &BumpDivs::BumpAllRelative { size }
-                => Rc::new(DividendStream::new_bump_all(&*divs, size)),
+                => RcDividendStream::new(Rc::new(DividendStream::new_bump_all(&*divs, size)))
         }
     }
 }

--- a/src/data/fixings.rs
+++ b/src/data/fixings.rs
@@ -17,6 +17,7 @@ impl FixingTable {
         fixings: &[(&str, &[(DateTime, f64)])]) 
         -> Result<FixingTable, qm::Error> {
 
+        // TODO we ought to be able to implement this in terms of from_iter_known_until
         let mut fixing_table = FixingTable::new(fixings_known_until);
         for fixing in fixings.iter() {
             let fixing_curve = Fixings::new(fixing.0, fixing.1)?;
@@ -25,15 +26,18 @@ impl FixingTable {
         Ok(fixing_table)
     }
 
-    /// TODO this is the same code as the above constructor. Needs templating
-    pub fn from_map(fixings_known_until: Date,
-        fixings: &HashMap<String, Vec<(DateTime, f64)>>) 
-        -> Result<FixingTable, qm::Error> {
-
-        let mut fixing_table = FixingTable::new(fixings_known_until);
-        for fixing in fixings.iter() {
-            let fixing_curve = Fixings::new(fixing.0, fixing.1)?;
-            fixing_table.insert(fixing.0, fixing_curve)?;
+    /// Creates a fixing table from a source such as a HashMap iterator, or an iterator from a slice
+    /// of pairs of ids and slices of Date
+    pub fn from_iter_known_until<T, U, V>(fixings_known_until: Date, iter: T) -> Result<FixingTable, qm::Error>
+    where 
+        T: IntoIterator<Item = (U, V)>,
+        U: AsRef<str>,
+        V: AsRef<[(DateTime, f64)]> {
+        
+       let mut fixing_table = FixingTable::new(fixings_known_until);
+        for fixing in iter {
+            let fixing_curve = Fixings::new(fixing.0.as_ref(), fixing.1.as_ref())?;
+            fixing_table.insert(fixing.0.as_ref(), fixing_curve)?;
         }
         Ok(fixing_table)
     }

--- a/src/data/forward.rs
+++ b/src/data/forward.rs
@@ -1,12 +1,11 @@
 use dates::Date;
-use dates::rules::DateRule;
+use dates::rules::RcDateRule;
 use math::interpolation::Interpolate;
 use data::divstream::DividendBootstrap;
 use data::divstream::DividendStream;
 use data::curves::RcRateCurve;
 use data::curves::RateCurve;
 use core::qm;
-use std::rc::Rc;
 
 /// Forward curve. This represents the expectation value of some asset over
 /// time. It is implemented in different ways for futures (generally driftless)
@@ -81,7 +80,7 @@ impl InterpolatedForward {
 /// An equity forward has a spot, a discount rate which, together with a
 /// borrow, defines the rate of growth, plus a dividend stream.
 pub struct EquityForward {
-    settlement: Rc<DateRule>,
+    settlement: RcDateRule,
     rate: RcRateCurve,
     borrow: RcRateCurve,
     div_yield: RcRateCurve,
@@ -120,7 +119,7 @@ impl EquityForward {
     pub fn new(
         base_date: Date,
         spot: f64,
-        settlement: Rc<DateRule>,
+        settlement: RcDateRule,
         rate: RcRateCurve,
         borrow: RcRateCurve,
         divs: &DividendStream,
@@ -194,6 +193,7 @@ mod tests {
     use data::divstream::Dividend;
     use dates::calendar::WeekdayCalendar;
     use dates::rules::BusinessDays;
+    use dates::calendar::RcCalendar;
 
     #[test]
     fn driftless_forward() {
@@ -228,8 +228,8 @@ mod tests {
         let divs = create_sample_divstream();
         let rate = create_sample_rate();
         let borrow = create_sample_borrow();
-        let calendar = Rc::new(WeekdayCalendar{});
-        let settlement = Rc::new(BusinessDays::new_step(calendar, 2));
+        let calendar = RcCalendar::new(Rc::new(WeekdayCalendar{}));
+        let settlement = RcDateRule::new(Rc::new(BusinessDays::new_step(calendar, 2)));
 
         let fwd = EquityForward::new(d, spot, settlement, rate, borrow, &divs,
             d + 1500).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,14 +2,18 @@ extern crate statrs;
 extern crate ndarray;
 extern crate nalgebra;
 extern crate rand;
+extern crate serde;
+//extern crate serde_state as serde;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde;
+//#[macro_use]
+//extern crate serde_derive_state;
 extern crate erased_serde;
 extern crate serde_tagged;
 extern crate serde_json;
 #[macro_use]
 extern crate lazy_static;
+extern crate void;
 
 // listed in dependency order, though this is not essential for compilation
 pub mod core;

--- a/src/models/blackdiffusion.rs
+++ b/src/models/blackdiffusion.rs
@@ -1,5 +1,4 @@
 use std::any::Any;
-use std::rc::Rc;
 use std::collections::HashMap;
 use rand;
 use rand::StdRng;
@@ -111,7 +110,7 @@ impl MonteCarloModelFactory for BlackDiffusionFactory {
 #[derive(Clone)]
 pub struct BlackDiffusion {
     observations: Vec<DateDayFraction>,
-    flows: Vec<Rc<Instrument>>,
+    flows: Vec<RcInstrument>,
     context: Box<BumpablePricingContext>,
     key: HashMap<String, usize>,
     instruments: Vec<RcInstrument>,
@@ -471,7 +470,7 @@ impl MonteCarloModel for BlackDiffusion {
 
 impl MonteCarloContext for BlackDiffusion {
 
-    fn paths(&self, instrument: &Rc<Instrument>)
+    fn paths(&self, instrument: &RcInstrument)
         -> Result<ArrayView2<f64>, qm::Error> {
 
         let id = instrument.id().to_string();

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -2,10 +2,8 @@ pub mod blackdiffusion;
 
 use std::collections::HashMap;
 use std::clone::Clone;
-use std::rc::Rc;
 use core::qm;
 use instruments::RcInstrument;
-use instruments::Instrument;
 use instruments::MonteCarloDependencies;
 use instruments::MonteCarloContext;
 use risk::Bumpable;
@@ -62,7 +60,7 @@ impl Clone for Box<MonteCarloModel> {
 pub struct MonteCarloTimeline {
     _spot_date: Date,
     observations: HashMap<RcInstrument, Vec<DateDayFraction>>,
-    flows: Vec<Rc<Instrument>>,
+    flows: Vec<RcInstrument>,
     collated: bool
 }
 
@@ -95,7 +93,7 @@ impl MonteCarloTimeline {
         &self.observations
     }
 
-    pub fn flows(&self) -> &[Rc<Instrument>] {
+    pub fn flows(&self) -> &[RcInstrument] {
         assert!(self.collated);
         &self.flows
     }
@@ -103,16 +101,16 @@ impl MonteCarloTimeline {
 
 impl MonteCarloDependencies for MonteCarloTimeline {
 
-    fn observation(&mut self, instrument: &Rc<Instrument>,
+    fn observation(&mut self, instrument: &RcInstrument,
         date_time: DateDayFraction) {
 
         // Record the observations in the order the client specifies them
         // for any one instrument
-        self.observations.entry(RcInstrument::new(instrument.clone()))
+        self.observations.entry(instrument.clone())
             .or_insert(Vec::<DateDayFraction>::new()).push(date_time);
     }
 
-    fn flow(&mut self, instrument: &Rc<Instrument>) {
+    fn flow(&mut self, instrument: &RcInstrument) {
 
         // We must record flows in the order the client specifies them, as
         // the client later relies on this order

--- a/src/pricers/mod.rs
+++ b/src/pricers/mod.rs
@@ -3,7 +3,7 @@ pub mod selfpricer;
 
 use core::qm;
 use std::rc::Rc;
-use instruments::Instrument;
+use instruments::RcInstrument;
 use data::fixings::FixingTable;
 use risk::marketdata::MarketData;
 use risk::Pricer;
@@ -15,7 +15,7 @@ pub trait PricerFactory {
     /// All the inputs are shared pointers to const objects, which allows them
     /// to be shared across multiple pricers. (Consider making them Arc rather
     /// than Rc, allowing multithreaded use across different pricers.)
-    fn new(&self, instrument: Rc<Instrument>, fixings: Rc<FixingTable>, 
+    fn new(&self, instrument: RcInstrument, fixings: Rc<FixingTable>, 
         market_data: Rc<MarketData>) -> Result<Box<Pricer>, qm::Error>;
 }
  

--- a/src/pricers/montecarlo.rs
+++ b/src/pricers/montecarlo.rs
@@ -1,6 +1,6 @@
 use core::qm;
 use std::rc::Rc;
-use instruments::Instrument;
+use instruments::RcInstrument;
 use instruments::PricingContext;
 use instruments::DependencyContext;
 use risk::cache::PricingContextPrefetch;
@@ -25,7 +25,7 @@ use models::MonteCarloTimeline;
 #[derive(Clone)]
 pub struct MonteCarloPricer {
     model_factory: Rc<MonteCarloModelFactory>,
-    instruments: Vec<(f64, Rc<Instrument>)>,
+    instruments: Vec<(f64, RcInstrument)>,
     model: Box<MonteCarloModel>
 }
 
@@ -52,7 +52,7 @@ impl MonteCarloPricerFactory {
 }
 
 impl PricerFactory for MonteCarloPricerFactory {
-    fn new(&self, instrument: Rc<Instrument>, fixing_table: Rc<FixingTable>, 
+    fn new(&self, instrument: RcInstrument, fixing_table: Rc<FixingTable>, 
         market_data: Rc<MarketData>) -> Result<Box<Pricer>, qm::Error> {
 
         // Apply the fixings to the instrument. (This is the last time we need
@@ -69,7 +69,7 @@ impl PricerFactory for MonteCarloPricerFactory {
 }
 
 impl MonteCarloPricer {
-    pub fn new(instruments:  Vec<(f64, Rc<Instrument>)>,
+    pub fn new(instruments:  Vec<(f64, RcInstrument)>,
         model_factory: Rc<MonteCarloModelFactory>, market_data: &MarketData)
         -> Result<MonteCarloPricer, qm::Error> {
 
@@ -201,7 +201,7 @@ mod tests {
         // the Monte-Carlo pricing against analytic.
 
         let market_data: Rc<MarketData> = Rc::new(sample_market_data());
-        let instrument: Rc<Instrument> = sample_european();
+        let instrument = RcInstrument::new(sample_european());
         let fixings: Rc<FixingTable> = Rc::new(sample_fixings());
 
         let n_paths = 100000;
@@ -295,7 +295,7 @@ mod tests {
         // the Monte-Carlo pricing against analytic.
 
         let market_data: Rc<MarketData> = Rc::new(sample_market_data());
-        let instrument: Rc<Instrument> = sample_forward_european();
+        let instrument = RcInstrument::new(sample_forward_european());
         let fixings: Rc<FixingTable> = Rc::new(sample_fixings());
 
         let n_paths = 100000;

--- a/src/pricers/selfpricer.rs
+++ b/src/pricers/selfpricer.rs
@@ -1,6 +1,6 @@
 use core::qm;
 use std::rc::Rc;
-use instruments::Instrument;
+use instruments::RcInstrument;
 use instruments::PricingContext;
 use instruments::DependencyContext;
 use risk::cache::PricingContextPrefetch;
@@ -24,7 +24,7 @@ use dates::datetime::TimeOfDay;
 /// interface as a Pricer, allowing bumping for risk calculation.
 #[derive(Clone)]
 pub struct SelfPricer {
-    instruments: Vec<(f64, Rc<Instrument>)>,
+    instruments: Vec<(f64, RcInstrument)>,
     context: PricingContextPrefetch
 }
 
@@ -42,7 +42,7 @@ impl SelfPricerFactory {
 }
 
 impl PricerFactory for SelfPricerFactory {
-    fn new(&self, instrument: Rc<Instrument>, fixing_table: Rc<FixingTable>, 
+    fn new(&self, instrument: RcInstrument, fixing_table: Rc<FixingTable>, 
         market_data: Rc<MarketData>) -> Result<Box<Pricer>, qm::Error> {
 
         // Apply the fixings to the instrument. (This is the last time we need
@@ -58,7 +58,7 @@ impl PricerFactory for SelfPricerFactory {
 }
 
 impl SelfPricer {
-    pub fn new(instruments:  Vec<(f64, Rc<Instrument>)>, 
+    pub fn new(instruments:  Vec<(f64, RcInstrument)>, 
         market_data: &MarketData) -> Result<SelfPricer, qm::Error> {
 
         // Find the dependencies of the resulting vector of instruments
@@ -172,7 +172,7 @@ mod tests {
     fn self_price_european_bumped_price() {
 
         let market_data: Rc<MarketData> = Rc::new(sample_market_data());
-        let instrument: Rc<Instrument> = sample_european();
+        let instrument = RcInstrument::new(sample_european());
         let fixings: Rc<FixingTable> = Rc::new(sample_fixings());
 
         let factory = SelfPricerFactory::new();
@@ -256,7 +256,7 @@ mod tests {
     fn self_price_forward_european_time_bumped() {
 
         let market_data: Rc<MarketData> = Rc::new(sample_market_data());
-        let instrument: Rc<Instrument> = sample_forward_european();
+        let instrument = RcInstrument::new(sample_forward_european());
         let fixings: Rc<FixingTable> = Rc::new(sample_fixings());
 
         let factory = SelfPricerFactory::new();

--- a/src/risk/bumptime.rs
+++ b/src/risk/bumptime.rs
@@ -2,9 +2,9 @@ use risk::Bumpable;
 use dates::Date;
 use dates::datetime::DateTime;
 use core::qm;
-use std::rc::Rc;
 use std::collections::HashMap;
 use instruments::Instrument;
+use instruments::RcInstrument;
 use instruments::fix_all;
 use instruments::PricingContext;
 use data::fixings::FixingTable;
@@ -31,7 +31,7 @@ impl BumpTime {
     /// changed, it also applies the bump to the model. If the list of instruments has
     /// changed, the model will need to be completely rebuilt. In that case, the method
     /// returns true.
-    pub fn apply(&self, instruments: &mut Vec<(f64, Rc<Instrument>)>,
+    pub fn apply(&self, instruments: &mut Vec<(f64, RcInstrument)>,
         bumpable: &mut Bumpable) -> Result<bool, qm::Error> {
 
         // Modify the vector of instruments, if any fixings between the old and new spot dates
@@ -53,7 +53,7 @@ impl BumpTime {
     /// Creates a fixing table representing any fixings between the old and new spot dates, and
     /// applies it to the instruments, modifying the vector if necessary. If any have changed,
     /// returns true.
-    pub fn update_instruments(&self, instruments: &mut Vec<(f64, Rc<Instrument>)>,
+    pub fn update_instruments(&self, instruments: &mut Vec<(f64, RcInstrument)>,
         context: &PricingContext, dependencies: &DependencyCollector) -> Result<bool, qm::Error> {
 
         // are there any fixings between the old and new spot dates?
@@ -89,7 +89,7 @@ impl BumpTime {
         // Apply the fixings to each of the instruments, and build up a new vector of them
         let mut any_changes = !fixing_map.is_empty();
         if any_changes {
-            let fixing_table = FixingTable::from_map(new_spot_date, &fixing_map)?;
+            let fixing_table = FixingTable::from_iter_known_until(new_spot_date, fixing_map.iter())?;
             if let Some(ref mut replacement) = fix_all(instruments, &fixing_table)? {
                 instruments.clear();
                 instruments.append(replacement);

--- a/src/risk/cache.rs
+++ b/src/risk/cache.rs
@@ -381,6 +381,7 @@ pub mod tests {
     use std::rc::Rc;
     use instruments::DependencyContext;
     use instruments::Priceable;
+    use instruments::RcInstrument;
     use math::numerics::approx_eq;
     use risk::marketdata::tests::sample_market_data;
     use risk::marketdata::tests::sample_european;
@@ -391,7 +392,7 @@ pub mod tests {
     use dates::datetime::DateTime;
     use dates::datetime::TimeOfDay;
 
-    pub fn create_dependencies(instrument: &Rc<Instrument>, spot_date: Date)
+    pub fn create_dependencies(instrument: &RcInstrument, spot_date: Date)
         -> Rc<DependencyCollector> {
 
         let mut collector = DependencyCollector::new(spot_date);
@@ -411,7 +412,7 @@ pub mod tests {
         // so we can modify it and also create an
         // empty saved data to save state so we can restore it
         let spot_date = Date::from_ymd(2017, 01, 02);
-        let instrument: Rc<Instrument> = european.clone();
+        let instrument = RcInstrument::new(european.clone());
         let dependencies = create_dependencies(&instrument, spot_date);
         let mut mut_data = PricingContextPrefetch::new(&market_data,
             dependencies).unwrap();

--- a/src/risk/deltagamma.rs
+++ b/src/risk/deltagamma.rs
@@ -91,7 +91,6 @@ impl ReportGenerator for DeltaGammaReportGenerator {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use std::rc::Rc;
     use math::numerics::approx_eq;
     use risk::marketdata::tests::sample_market_data;
     use risk::marketdata::tests::sample_european;
@@ -102,7 +101,7 @@ pub mod tests {
     use risk::dependencies::DependencyCollector;
     use risk::cache::PricingContextPrefetch;
     use instruments::PricingContext;
-    use instruments::Instrument;
+    use instruments::RcInstrument;
     use risk::cache::tests::create_dependencies;
     use dates::datetime::DateTime;
     use dates::datetime::TimeOfDay;
@@ -110,7 +109,7 @@ pub mod tests {
     // a sample pricer that evaluates european options
     #[derive(Clone)]
     struct SamplePricer {
-        instruments: Vec<(f64, Rc<Instrument>)>,
+        instruments: Vec<(f64, RcInstrument)>,
         context: PricingContextPrefetch
     }
 
@@ -120,7 +119,7 @@ pub mod tests {
         let european = sample_european();
  
         let spot_date = market_data.spot_date();
-        let instrument: Rc<Instrument> = european.clone();
+        let instrument = RcInstrument::new(european.clone());
         let dependencies = create_dependencies(&instrument, spot_date);
         let context = PricingContextPrefetch::new(&market_data,
             dependencies).unwrap();


### PR DESCRIPTION
This initial commit does not use the deduplication for any real QuantMath objects. That is likely to be rather more complicated, because we also want to support polymorphism.

This commit also includes polymorphic serialization for many types.