### PR TITLE
Deduplication for currencies and instruments

### DIFF
--- a/src/instruments/bonds.rs
+++ b/src/instruments/bonds.rs
@@ -10,12 +10,13 @@ use instruments::DependencyContext;
 use instruments::SpotRequirement;
 use instruments::assets::Currency;
 use instruments::assets::RcCurrency;
-use instruments::RcInstrument;
 use dates::Date;
 use dates::datetime::DateTime;
 use dates::rules::RcDateRule;
 use core::qm;
 use core::factories::TypeId;
+use core::factories::Qrc;
+use core::dedup::InstanceId;
 use serde::Deserialize;
 use erased_serde as esd;
 
@@ -34,6 +35,10 @@ impl TypeId for ZeroCoupon {
     fn type_id(&self) -> &'static str { "ZeroCoupon" }
 }
 
+impl InstanceId for ZeroCoupon {
+    fn id(&self) -> &str { &self.id }
+}
+
 impl ZeroCoupon {
     /// Creates a zero coupon bond. It must have an id that uniquely
     /// represents it. It is discounted according to the yield curve
@@ -50,15 +55,12 @@ impl ZeroCoupon {
             settlement: settlement }
     }
 
-    pub fn from_serial<'de>(de: &mut esd::Deserializer<'de>) -> Result<RcInstrument, esd::Error> {
-        Ok(RcInstrument::new(Rc::new(ZeroCoupon::deserialize(de)?)))
+    pub fn from_serial<'de>(de: &mut esd::Deserializer<'de>) -> Result<Qrc<Instrument>, esd::Error> {
+        Ok(Qrc::new(Rc::new(ZeroCoupon::deserialize(de)?)))
     }
 }
 
 impl Instrument for ZeroCoupon {
-    fn id(&self) -> &str {
-        &self.id
-    }
 
     fn payoff_currency(&self) -> &Currency {
         &*self.currency

--- a/src/pricers/montecarlo.rs
+++ b/src/pricers/montecarlo.rs
@@ -184,6 +184,7 @@ mod tests {
     use risk::marketdata::tests::sample_european;
     use risk::marketdata::tests::sample_forward_european;
     use models::blackdiffusion::BlackDiffusionFactory;
+    use core::factories::Qrc;
 
     fn sample_fixings() -> FixingTable {
         let today = Date::from_ymd(2017, 01, 02);
@@ -201,7 +202,7 @@ mod tests {
         // the Monte-Carlo pricing against analytic.
 
         let market_data: Rc<MarketData> = Rc::new(sample_market_data());
-        let instrument = RcInstrument::new(sample_european());
+        let instrument = RcInstrument::new(Qrc::new(sample_european()));
         let fixings: Rc<FixingTable> = Rc::new(sample_fixings());
 
         let n_paths = 100000;
@@ -295,7 +296,7 @@ mod tests {
         // the Monte-Carlo pricing against analytic.
 
         let market_data: Rc<MarketData> = Rc::new(sample_market_data());
-        let instrument = RcInstrument::new(sample_forward_european());
+        let instrument = RcInstrument::new(Qrc::new(sample_forward_european()));
         let fixings: Rc<FixingTable> = Rc::new(sample_fixings());
 
         let n_paths = 100000;

--- a/src/pricers/selfpricer.rs
+++ b/src/pricers/selfpricer.rs
@@ -160,6 +160,7 @@ mod tests {
     use risk::marketdata::tests::sample_market_data;
     use risk::marketdata::tests::sample_european;
     use risk::marketdata::tests::sample_forward_european;
+    use core::factories::Qrc;
 
     fn sample_fixings() -> FixingTable {
         let today = Date::from_ymd(2017, 01, 02);
@@ -172,7 +173,7 @@ mod tests {
     fn self_price_european_bumped_price() {
 
         let market_data: Rc<MarketData> = Rc::new(sample_market_data());
-        let instrument = RcInstrument::new(sample_european());
+        let instrument = RcInstrument::new(Qrc::new(sample_european()));
         let fixings: Rc<FixingTable> = Rc::new(sample_fixings());
 
         let factory = SelfPricerFactory::new();
@@ -256,7 +257,7 @@ mod tests {
     fn self_price_forward_european_time_bumped() {
 
         let market_data: Rc<MarketData> = Rc::new(sample_market_data());
-        let instrument = RcInstrument::new(sample_forward_european());
+        let instrument = RcInstrument::new(Qrc::new(sample_forward_european()));
         let fixings: Rc<FixingTable> = Rc::new(sample_fixings());
 
         let factory = SelfPricerFactory::new();

--- a/src/risk/cache.rs
+++ b/src/risk/cache.rs
@@ -391,6 +391,7 @@ pub mod tests {
     use data::bumpyield::BumpYield;
     use dates::datetime::DateTime;
     use dates::datetime::TimeOfDay;
+    use core::factories::Qrc;
 
     pub fn create_dependencies(instrument: &RcInstrument, spot_date: Date)
         -> Rc<DependencyCollector> {
@@ -412,7 +413,7 @@ pub mod tests {
         // so we can modify it and also create an
         // empty saved data to save state so we can restore it
         let spot_date = Date::from_ymd(2017, 01, 02);
-        let instrument = RcInstrument::new(european.clone());
+        let instrument = RcInstrument::new(Qrc::new(european.clone()));
         let dependencies = create_dependencies(&instrument, spot_date);
         let mut mut_data = PricingContextPrefetch::new(&market_data,
             dependencies).unwrap();

--- a/src/risk/deltagamma.rs
+++ b/src/risk/deltagamma.rs
@@ -105,6 +105,7 @@ pub mod tests {
     use risk::cache::tests::create_dependencies;
     use dates::datetime::DateTime;
     use dates::datetime::TimeOfDay;
+    use core::factories::Qrc;
 
     // a sample pricer that evaluates european options
     #[derive(Clone)]
@@ -119,7 +120,7 @@ pub mod tests {
         let european = sample_european();
  
         let spot_date = market_data.spot_date();
-        let instrument = RcInstrument::new(european.clone());
+        let instrument = RcInstrument::new(Qrc::new(european.clone()));
         let dependencies = create_dependencies(&instrument, spot_date);
         let context = PricingContextPrefetch::new(&market_data,
             dependencies).unwrap();

--- a/src/risk/dependencies.rs
+++ b/src/risk/dependencies.rs
@@ -208,6 +208,7 @@ mod tests {
     use instruments::options::PutOrCall;
     use instruments::options::OptionSettlement;
     use dates::rules::RcDateRule;
+    use core::factories::Qrc;
     use std::rc::Rc;
 
     fn sample_currency(step: u32) -> Currency {
@@ -236,15 +237,15 @@ mod tests {
 
         let currency = RcCurrency::new(Rc::new(sample_currency(2)));
         let settlement = sample_settlement(2);
-        let equity: RcInstrument = RcInstrument::new(Rc::new(sample_equity(currency, 2)));
-        let short_european: RcInstrument = RcInstrument::new(Rc::new(SpotStartingEuropean::new(
+        let equity: RcInstrument = RcInstrument::new(Qrc::new(Rc::new(sample_equity(currency, 2))));
+        let short_european: RcInstrument = RcInstrument::new(Qrc::new(Rc::new(SpotStartingEuropean::new(
             "ShortDatedEquity",
             "OPT", equity.clone(), settlement.clone(), short_expiry,
-            strike, PutOrCall::Call, OptionSettlement::Cash).unwrap()));
-        let long_european: RcInstrument = RcInstrument::new(Rc::new(SpotStartingEuropean::new(
+            strike, PutOrCall::Call, OptionSettlement::Cash).unwrap())));
+        let long_european: RcInstrument = RcInstrument::new(Qrc::new(Rc::new(SpotStartingEuropean::new(
             "LongDatedEquity",
             "OPT", equity.clone(), settlement, long_expiry,
-            strike, PutOrCall::Call, OptionSettlement::Cash).unwrap()));
+            strike, PutOrCall::Call, OptionSettlement::Cash).unwrap())));
 
         let mut c = DependencyCollector::new(d);
         c.spot(&short_european);

--- a/src/risk/marketdata.rs
+++ b/src/risk/marketdata.rs
@@ -376,6 +376,7 @@ pub mod tests {
     use dates::calendar::RcCalendar;
     use math::numerics::approx_eq;
     use math::interpolation::Extrap;
+    use core::factories::Qrc;
     use serde_json;
 
     pub fn sample_currency(step: u32) -> Currency {
@@ -402,7 +403,7 @@ pub mod tests {
             Date::from_ymd(2018, 06, 01), TimeOfDay::Close);
         let currency = RcCurrency::new(Rc::new(sample_currency(2)));
         let settlement = sample_settlement(2);
-        let equity = RcInstrument::new(Rc::new(sample_equity(currency, 2)));
+        let equity = RcInstrument::new(Qrc::new(Rc::new(sample_equity(currency, 2))));
         let european = SpotStartingEuropean::new("SampleSpotEuropean", "OPT",
             equity.clone(), settlement, expiry,
             strike, put_or_call, OptionSettlement::Cash).unwrap();
@@ -419,7 +420,7 @@ pub mod tests {
             Date::from_ymd(2018, 06, 01), TimeOfDay::Close);
         let currency = RcCurrency::new(Rc::new(sample_currency(2)));
         let settlement = sample_settlement(2);
-        let equity = RcInstrument::new(Rc::new(sample_equity(currency, 2)));
+        let equity = RcInstrument::new(Qrc::new(Rc::new(sample_equity(currency, 2))));
         let european = ForwardStartingEuropean::new("SampleForwardEuropean", "OPT",
             equity.clone(), settlement, expiry,
             strike_fraction, strike_date, put_or_call, OptionSettlement::Cash).unwrap();


### PR DESCRIPTION
So far tested only for currencies, which is the easier case. Instruments are polymorphic, so have a whole host of extra complications.