### PR TITLE
Create Facade module

### DIFF
--- a/src/core/dedup.rs
+++ b/src/core/dedup.rs
@@ -301,6 +301,24 @@ where
     deserializer.deserialize_any(StringOrStruct(PhantomData))
 }
 
+/// Utility function to convert a slice of objects that support InstanceId into a
+/// HashMap. We do this rather than using a HashSet and relying on the object's own
+/// equality and hash methods, because we do not want to force every user of dedup
+/// to apply equality and hash only to its id.
+pub fn dedup_map_from_slice<T, R>(slice: &[Drc<T, R>]) -> HashMap<String, Drc<T, R>>
+where
+    T: InstanceId + Debug + ?Sized,
+    R: Deref<Target = T> + Clone,
+    Drc<T, R>: FromId
+{
+    let mut map = HashMap::new();
+    for item in slice.iter() {
+        let id = item.id();
+        map.insert(id.to_string(), item.clone());
+    }
+    map
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/core/qm.rs
+++ b/src/core/qm.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use std::io;
 use std::num;
 use ndarray;
+use serde_json;
 
 /// Error returned by any rfin method
 #[derive(Debug)]
@@ -47,6 +48,12 @@ impl From<num::ParseIntError> for Error {
 impl From<ndarray::ShapeError> for Error {
     fn from(error: ndarray::ShapeError) -> Self {
         Error::new(&format!("Error {} when converting array", error))
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(error: serde_json::Error) -> Self {
+        Error::new(&format!("Error {} when serializing/deserializing", error))
     }
 }
 

--- a/src/data/bumpspotdate.rs
+++ b/src/data/bumpspotdate.rs
@@ -5,7 +5,7 @@ use dates::Date;
 /// data, but does not modify any instruments. As a result, you may end up with
 /// code that works most of the time, but fails when the change of spot date
 /// straddles a lifecycle event.
-#[derive(Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct BumpSpotDate {
     spot_date: Date,
     spot_dynamics: SpotDynamics
@@ -21,7 +21,7 @@ impl BumpSpotDate {
 }
 
 /// Enum that defines how spot moves when time is bumped.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Hash)]
 pub enum SpotDynamics {
     /// Spot stays the same, except that any dividends going ex are subtracted
     StickySpot,

--- a/src/data/bumpvol.rs
+++ b/src/data/bumpvol.rs
@@ -8,7 +8,7 @@ use data::bump::Bumper;
 
 /// Bump that defines all the supported bumps and risk transformations of a
 /// vol surface.
-#[derive(Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub enum BumpVol {
     FlatAdditive { size: f64 },
     TimeScaled { size: f64, floor: f64 },

--- a/src/facade/mod.rs
+++ b/src/facade/mod.rs
@@ -1,0 +1,484 @@
+use instruments::{RcInstrument, Instrument, DEDUP_INSTRUMENT};
+use instruments::assets::{RcCurrency, Currency, DEDUP_CURRENCY};
+use pricers::RcPricerFactory;
+use data::fixings::RcFixingTable;
+use risk::RcReportGenerator;
+use risk::marketdata::RcMarketData;
+use core::dedup::{Dedup, DedupControl, dedup_map_from_slice};
+use core::factories::Qrc;
+use core::qm;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_json as sdj;
+use std::io::{Read, Write};
+use std::rc::Rc;
+
+/// An instrument in QuantMath represents any tradable item. At simplest, it can be
+/// a currency, zero coupon bond, equity or commodity. At most complex, it can be
+/// a dynamic index or complex exotic product.
+/// 
+/// Most instruments have recursive definitions, depending on other instruments and
+/// currencies. (A currency is a type of instrument, but is normally treated separately
+/// as currencies cannot normally be replaced with other instruments.) The subcomponents
+/// can be passed into this call, or expanded inline. Control of this behaviour is by
+/// the ccy_dedup and instr_dedup parameters, and precomputed currencies and instruments
+/// may be passed into this call (depending on the dedup parameters).
+/// 
+/// The source is any source of UTF-8 bytes, such as a file or string.
+pub fn instrument_from_json(source: &mut Read,
+    ccy_dedup: DedupControl, currencies: &[RcCurrency],
+    instr_dedup: DedupControl, instruments: &[RcInstrument]) 
+    -> Result<RcInstrument, qm::Error> {
+
+    // create a deserializer based on the input
+    let mut deserializer = sdj::Deserializer::from_reader(source);
+
+    // convert the currencies and instrument components to maps, for efficient deduplication
+    let currencies_map = dedup_map_from_slice(currencies);
+    let instruments_map = dedup_map_from_slice(instruments);
+
+    let mut ccy = Dedup::<Currency, Rc<Currency>>::new(ccy_dedup, currencies_map);
+    let mut opt = Dedup::<Instrument, Qrc<Instrument>>::new(instr_dedup, instruments_map);
+    let instr = ccy.with(&DEDUP_CURRENCY, 
+        || opt.with(&DEDUP_INSTRUMENT,
+        || RcInstrument::deserialize(&mut deserializer)))?;
+    Ok(instr)
+}
+
+/// A currency in QuantMath normally represents a literal currency such as USD. For simplicity
+/// we recommend that only major currencies are used. Thus a penny is represented as 0.01 GBP
+/// rather than 1 gbp. Currencies may also be used to represent some precious metal commodities
+/// such a XAU.
+/// 
+/// A currency is also an instrument, though normally currencies and instruments are treated
+/// separately. An exception would be where a currency is contained in a basket, meaning cash
+/// that is not discounted.
+/// The source is any source of UTF-8 bytes, such as a file or string.
+pub fn currency_from_json(source: &mut Read) 
+    -> Result<RcCurrency, qm::Error> {
+
+    // create a deserializer based on the input and use it to deserialize the currency
+    let mut deserializer = sdj::Deserializer::from_reader(source);
+    let currency = RcCurrency::deserialize(&mut deserializer)?;
+    Ok(currency)
+}
+
+/// A PricerFactory is used to create pricers, given an instrument to price and a fixing table.
+/// It contains enough information to define how the pricing is done, for example whether it is
+/// Monte-Carlo, how many paths, and which model to use.
+pub fn pricer_factory_from_json(source: &mut Read)
+    -> Result<RcPricerFactory, qm::Error> {
+
+    // create a deserializer based on the input and use it to deserialize the pricer factory
+    let mut deserializer = sdj::Deserializer::from_reader(source);
+    let pricer_factory = RcPricerFactory::deserialize(&mut deserializer)?;
+    Ok(pricer_factory)
+}
+
+/// A FixingTable contains historical fixings for one or more assets, defined by Date and time of
+/// day.
+pub fn fixing_table_from_json(source: &mut Read)
+    -> Result<RcFixingTable, qm::Error> {
+
+    // create a deserializer based on the input and use it to deserialize the pricer factory
+    let mut deserializer = sdj::Deserializer::from_reader(source);
+    let fixing_table = RcFixingTable::deserialize(&mut deserializer)?;
+    Ok(fixing_table)
+}
+
+/// MarketData contains all the live market data required for pricing. This is spots, yield
+/// and borrow curves, dividends, volatilities, and correlations. You can instantiate a
+/// MarketData as here by deserializing it from json. It may be more efficient to instantiate
+/// it directly, by using methods in the data module.
+pub fn market_data_from_json(source: &mut Read)
+    -> Result<RcMarketData, qm::Error> {
+
+    // create a deserializer based on the input and use it to deserialize the pricer factory
+    let mut deserializer = sdj::Deserializer::from_reader(source);
+    let market_data = RcMarketData::deserialize(&mut deserializer)?;
+    Ok(market_data)
+}
+
+/// A ReportGenerator takes a pricer and bumps and revalues it to generate a report
+/// of sensitivities to market data changes.
+pub fn report_generator_from_json(source: &mut Read)
+    -> Result<RcReportGenerator, qm::Error> {
+
+    // create a deserializer based on the input and use it to deserialize the pricer factory
+    let mut deserializer = sdj::Deserializer::from_reader(source);
+    let report_generator = RcReportGenerator::deserialize(&mut deserializer)?;
+    Ok(report_generator)
+}
+
+/// Performs a calculation, outputting the price, and writing any reports that are
+/// requested.
+pub fn calculate(pricer_factory: RcPricerFactory, instrument: RcInstrument, 
+    fixing_table: RcFixingTable, market_data: RcMarketData,
+    report_generators: &[RcReportGenerator], pretty: bool, out: &mut Write)
+    -> Result<f64, qm::Error> {
+
+    let mut pricer = pricer_factory.new(instrument, fixing_table, market_data)?;
+    let price = pricer.price()?;
+    let mut saveable = pricer.as_bumpable().new_saveable();
+
+    let mut reports = Vec::with_capacity(report_generators.len());
+    for report_generator in report_generators.iter() {
+        let report = report_generator.generate(&mut *pricer, &mut *saveable, price)?;
+        reports.push(report);
+    }
+
+    serialize_output(&reports, pretty, out)?;
+
+    Ok(price)
+}
+
+fn serialize_output<T>(to_write: &T, pretty: bool, out: &mut Write) -> Result<(), qm::Error>
+where T: Serialize {
+    if pretty {
+        let mut serializer = sdj::Serializer::pretty(out);
+        to_write.serialize(&mut serializer)?;
+    } else {
+        let mut serializer = sdj::Serializer::new(out);
+        to_write.serialize(&mut serializer)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+    use math::numerics::approx_eq;
+    use std::str::from_utf8;
+
+    #[test]
+    fn facade_forward_starting_european_price() {
+
+        let pricer_factory = pricer_factory_from_json(
+            &mut Cursor::new(sample_pricer_factory_json())).unwrap();
+
+        let european = instrument_from_json(
+            &mut Cursor::new(sample_forward_european_json()),
+            DedupControl::WriteOnce, &[],
+            DedupControl::WriteOnce, &[]).unwrap();
+
+        let market_data = market_data_from_json(
+            &mut Cursor::new(sample_market_data_json())).unwrap();
+        
+        let fixing_table = fixing_table_from_json(
+            &mut Cursor::new(sample_fixing_table_json())).unwrap();
+
+        let delta_gamma = report_generator_from_json(
+            &mut Cursor::new(sample_report_generator_json())).unwrap();
+
+        let mut buffer = Vec::new();
+        let price = calculate(pricer_factory, european, fixing_table, market_data,
+            &vec![delta_gamma], true, &mut Cursor::new(&mut buffer)).unwrap();
+
+        assert_approx(price, 3.7505621830857376, 1e-12);
+
+        // We need a way of comparing two JSON strings for equality, allowing for
+        // some approximation of floating point numbers, and possibly some flexibility
+        // in things like the ordering of elements.
+        let output = from_utf8(&buffer).unwrap();
+        print!("{}", output);
+    }
+
+    fn assert_approx(value: f64, expected: f64, tolerance: f64) {
+        assert!(approx_eq(value, expected, tolerance),
+            "value={} expected={}", value, expected);
+    }
+
+    fn sample_forward_european_json() -> &'static [u8] {
+        br###"{
+  "ForwardStartingEuropean": {
+    "id": "SampleEuropean",
+    "credit_id": "OPT",
+    "underlying": {
+      "Equity": {
+        "id": "BP.L",
+        "credit_id": "LSE",
+        "currency": {
+          "id": "GBP",
+          "settlement": {
+            "BusinessDays": {
+              "calendar": {
+                "WeekdayCalendar": []
+              },
+              "step": 2,
+              "slip_forward": true
+            }
+          }
+        },
+        "settlement": {
+          "BusinessDays": {
+            "calendar": {
+              "WeekdayCalendar": []
+            },
+            "step": 2,
+            "slip_forward": true
+          }
+        }
+      }
+    },
+    "settlement": {
+      "BusinessDays": {
+        "calendar": {
+          "WeekdayCalendar": []
+        },
+        "step": 2,
+        "slip_forward": true
+      }
+    },
+    "expiry": {
+      "date": "2018-12-01",
+      "time_of_day": "Close"
+    },
+    "put_or_call": "Call",
+    "cash_or_physical": "Cash",
+    "expiry_time": {
+      "date": "2018-12-01",
+      "day_fraction": 0.8
+    },
+    "pay_date": "2018-12-05",
+    "strike_fraction": 1.15170375,
+    "strike_date": {
+      "date": "2018-06-08",
+      "time_of_day": "Close"
+    },
+    "strike_time": {
+      "date": "2018-06-08",
+      "day_fraction": 0.8
+    }
+  }
+}"###
+    }
+
+    fn sample_market_data_json() -> &'static [u8] {
+        br###"{
+  "spot_date": "2017-01-02",
+  "spots": {
+    "BP.L": 100.0
+  },
+  "yield_curves": {
+    "OPT": {
+      "RateCurveAct365": {
+        "base": "2016-12-30",
+        "interp": {
+          "left": "Flat",
+          "right": "Flat",
+          "points": [
+            [
+              "2016-12-30",
+              0.05
+            ],
+            [
+              "2017-01-13",
+              0.08
+            ],
+            [
+              "2017-06-30",
+              0.09
+            ],
+            [
+              "2017-12-29",
+              0.085
+            ],
+            [
+              "2018-12-28",
+              0.082
+            ]
+          ]
+        }
+      }
+    },
+    "LSE": {
+      "RateCurveAct365": {
+        "base": "2016-12-30",
+        "interp": {
+          "left": "Flat",
+          "right": "Flat",
+          "points": [
+            [
+              "2016-12-30",
+              0.05
+            ],
+            [
+              "2017-01-13",
+              0.08
+            ],
+            [
+              "2017-06-30",
+              0.09
+            ],
+            [
+              "2017-12-29",
+              0.085
+            ],
+            [
+              "2018-12-28",
+              0.082
+            ]
+          ]
+        }
+      }
+    }
+  },
+  "borrow_curves": {
+    "BP.L": {
+      "RateCurveAct365": {
+        "base": "2016-12-30",
+        "interp": {
+          "left": "Flat",
+          "right": "Flat",
+          "points": [
+            [
+              "2016-12-30",
+              0.01
+            ],
+            [
+              "2017-07-14",
+              0.012
+            ],
+            [
+              "2017-12-29",
+              0.0125
+            ],
+            [
+              "2018-12-28",
+              0.012
+            ]
+          ]
+        }
+      }
+    }
+  },
+  "dividends": {
+    "BP.L": {
+      "dividends": [
+        {
+          "cash": 1.2,
+          "relative": 0.0,
+          "ex_date": "2017-01-30",
+          "pay_date": "2017-02-01"
+        },
+        {
+          "cash": 0.8,
+          "relative": 0.002,
+          "ex_date": "2017-07-31",
+          "pay_date": "2017-08-02"
+        },
+        {
+          "cash": 0.2,
+          "relative": 0.008,
+          "ex_date": "2018-01-29",
+          "pay_date": "2018-01-31"
+        },
+        {
+          "cash": 0.0,
+          "relative": 0.01,
+          "ex_date": "2018-07-30",
+          "pay_date": "2018-08-01"
+        }
+      ],
+      "div_yield": {
+        "RateCurveAct365": {
+          "base": "2019-01-02",
+          "interp": {
+            "left": "Zero",
+            "right": "Flat",
+            "points": [
+              [
+                "2019-01-02",
+                0.002
+              ],
+              [
+                "2020-01-02",
+                0.004
+              ],
+              [
+                "2022-01-01",
+                0.01
+              ],
+              [
+                "2026-12-31",
+                0.015
+              ]
+            ]
+          }
+        }
+      },
+      "last_cash_ex_date": "2018-01-29"
+    }
+  },
+  "vol_surfaces": {
+    "BP.L": {
+      "FlatVolSurface": {
+        "vol": 0.3,
+        "calendar": {
+          "WeekdayCalendar": []
+        },
+        "base_date": {
+          "date": "2016-12-30",
+          "day_fraction": 0.2
+        }
+      }
+    }
+  }
+}"###
+    }
+
+    fn sample_fixing_table_json() -> &'static [u8] {
+        br###"{
+  "fixings_known_until": "2018-01-01",
+  "fixings_by_id": {
+    "BP.L": {
+      "fixing_by_date": [
+        [
+          {
+            "date": "2017-12-25",
+            "time_of_day": "Close"
+          },
+          123.3
+        ],
+        [
+          {
+            "date": "2017-12-23",
+            "time_of_day": "Open"
+          },
+          123.1
+        ],
+        [
+          {
+            "date": "2018-01-01",
+            "time_of_day": "Open"
+          },
+          123.4
+        ],
+        [
+          {
+            "date": "2017-12-25",
+            "time_of_day": "Open"
+          },
+          123.2
+        ]
+      ]
+    }
+  }
+}"###
+    }
+
+    fn sample_report_generator_json() -> &'static [u8] {
+        br###"{
+  "DeltaGammaReportGenerator": {
+    "bumpsize": 0.01
+  }
+}"###
+    }
+
+    fn sample_pricer_factory_json() -> &'static [u8] {
+        br###"{
+  "SelfPricerFactory": {}
+}"###
+    }
+}

--- a/src/instruments/assets.rs
+++ b/src/instruments/assets.rs
@@ -172,24 +172,6 @@ impl<'de> sd::Deserialize<'de> for RcCurrency {
     }
 }
 
-/*
-impl sd::Serialize for RcCurrency {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where S: sd::Serializer
-    {
-        self.0.serialize(serializer)
-    }
-}
-
-impl<'de> sd::Deserialize<'de> for RcCurrency {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where D: sd::Deserializer<'de> {
-        let ccy = Currency::deserialize(deserializer)?;
-        Ok(RcCurrency::new(Rc::new(ccy)))
-    }
-}
-*/
-
 /// Represents an equity single name or index. Can also be used to represent
 /// funds and ETFs,
 

--- a/src/instruments/mod.rs
+++ b/src/instruments/mod.rs
@@ -36,7 +36,6 @@ use std::hash::Hasher;
 use std::f64::NAN;
 use std::fmt::Debug;
 use std::fmt;
-use std::ops::Deref;
 use ndarray::ArrayView2;
 use erased_serde as esd;
 use serde as sd;
@@ -212,16 +211,6 @@ pub fn get_registry() -> &'static TypeRegistry {
 /// should be unique across all instrument types.
 pub type RcInstrument = Drc<Instrument, Qrc<Instrument>>;
 
-impl RcInstrument {
-    pub fn id(&self) -> &str {
-        self.deref().id()
-    }
-
-    pub fn instrument(&self) -> &Instrument {
-        self.deref()
-    }
-}
-
 impl Ord for RcInstrument {
     fn cmp(&self, other: &RcInstrument) -> Ordering {
         self.id().cmp(other.id())
@@ -251,7 +240,7 @@ impl Hash for RcInstrument {
 /// Support for deduplication of instruments when serializing and deserializing
 
 thread_local! {
-    static DEDUP_INSTRUMENT : RefCell<Dedup<Instrument, Qrc<Instrument>>> 
+    pub static DEDUP_INSTRUMENT : RefCell<Dedup<Instrument, Qrc<Instrument>>> 
         = RefCell::new(Dedup::new(DedupControl::Inline, HashMap::new()));
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,3 +25,4 @@ pub mod risk;
 pub mod models;
 pub mod pricers;
 pub mod solvers;
+pub mod facade;

--- a/src/pricers/mod.rs
+++ b/src/pricers/mod.rs
@@ -1,21 +1,56 @@
 pub mod montecarlo;
 pub mod selfpricer;
 
+use pricers::montecarlo::MonteCarloPricerFactory;
+use pricers::selfpricer::SelfPricerFactory;
 use core::qm;
-use std::rc::Rc;
+use core::factories::{TypeId, Qrc, Registry};
 use instruments::RcInstrument;
-use data::fixings::FixingTable;
-use risk::marketdata::MarketData;
+use data::fixings::RcFixingTable;
+use risk::marketdata::RcMarketData;
 use risk::Pricer;
+use erased_serde as esd;
+use serde as sd;
+use serde_tagged as sdt;
+use serde_tagged::de::BoxFnSeed;
+use std::fmt::Debug;
 
 /// Pricers are always constructed using a pricer factory. This means that the
 /// code to create the pricer is independent of what sort of pricer it is.
-pub trait PricerFactory {
+pub trait PricerFactory : esd::Serialize + TypeId + Debug {
     /// Creates a pricer, given all the data that is needed to get a price.
     /// All the inputs are shared pointers to const objects, which allows them
     /// to be shared across multiple pricers. (Consider making them Arc rather
     /// than Rc, allowing multithreaded use across different pricers.)
-    fn new(&self, instrument: RcInstrument, fixings: Rc<FixingTable>, 
-        market_data: Rc<MarketData>) -> Result<Box<Pricer>, qm::Error>;
+    fn new(&self, instrument: RcInstrument, fixings: RcFixingTable, 
+        market_data: RcMarketData) -> Result<Box<Pricer>, qm::Error>;
 }
- 
+
+// Get serialization to work recursively for instruments by using the
+// technology defined in core/factories. RcInstrument is a container
+// class holding an RcInstrument
+pub type TypeRegistry = Registry<BoxFnSeed<Qrc<PricerFactory>>>;
+
+/// Implement deserialization for subclasses of the type
+impl<'de> sd::Deserialize<'de> for Qrc<PricerFactory> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where D: sd::Deserializer<'de>
+    {
+        sdt::de::external::deserialize(deserializer, get_registry())
+    }
+}
+
+/// Return the type registry required for deserialization.
+pub fn get_registry() -> &'static TypeRegistry {
+    lazy_static! {
+        static ref REG: TypeRegistry = {
+            let mut reg = TypeRegistry::new();
+            reg.insert("MonteCarloPricerFactory", BoxFnSeed::new(MonteCarloPricerFactory::from_serial));
+            reg.insert("SelfPricerFactory", BoxFnSeed::new(SelfPricerFactory::from_serial));
+            reg
+        };
+    }
+    &REG
+}
+
+pub type RcPricerFactory = Qrc<PricerFactory>;

--- a/src/risk/bumptime.rs
+++ b/src/risk/bumptime.rs
@@ -16,6 +16,7 @@ use risk::dependencies::DependencyCollector;
 /// Bump that defines all the supported bumps to the spot date and ex-from
 /// date. This bump has to live in risk rather than data, because it affects
 /// all market data, not just one curve at a time.
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct BumpTime {
     spot_date_bump: BumpSpotDate,
     _ex_from: Date

--- a/src/risk/cache.rs
+++ b/src/risk/cache.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 use std::collections::HashMap;
 use std::any::Any;
+use std::ops::Deref;
 use data::volsurface::RcVolSurface;
 use data::forward::Forward;
 use data::curves::RcRateCurve;
@@ -149,7 +150,7 @@ fn walk_dependencies(
     for (rc_instrument, high_water_mark) in &*forward_dependencies {
 
         // fetch the forward curve
-        let instrument = rc_instrument.instrument();
+        let instrument : &Instrument = rc_instrument.deref();
         let id = instrument.id().to_string();
         let forward = context.forward_curve(instrument, *high_water_mark)?;
 

--- a/src/solvers/impliedvol.rs
+++ b/src/solvers/impliedvol.rs
@@ -53,7 +53,7 @@ fn single_vol_id(pricer: &Pricer) -> Result<String, qm::Error> {
         return Err(qm::Error::new("Vol surface is not unambiguously defined"))
     }
     for (instrument, _) in vols {
-        return Ok(instrument.instrument().id().to_string())
+        return Ok(instrument.id().to_string())
     }
 
     Err(qm::Error::new("No vol surface to solve for"))


### PR DESCRIPTION
The facade is an easy-to-use data-driven interface to QuantMath. It can be used alongside lower-level calls. For example, the facade could be used to create an instrument, while the market data could be supplied by direct calls into the data module.

The facade is currently Rust code, but the intention is to mirror the functions in the facade with C-style or JNI interfaces, to allow interoperability with other languages.

As part of this checkin, complete the serialization and deserialization of all objects required for pricing.