### PR TITLE
Thread safety

### DIFF
--- a/src/data/bumpdivs.rs
+++ b/src/data/bumpdivs.rs
@@ -1,7 +1,7 @@
 use data::divstream::RcDividendStream;
 use data::divstream::DividendStream;
 use data::bump::Bumper;
-use std::rc::Rc;
+use std::sync::Arc;
 
 /// Bump that defines all the supported bumps and risk transformations of a
 /// vol surface.
@@ -20,7 +20,7 @@ impl Bumper<RcDividendStream> for BumpDivs {
     fn apply(&self, divs: RcDividendStream) -> RcDividendStream {
         match self {
             &BumpDivs::BumpAllRelative { size }
-                => RcDividendStream::new(Rc::new(DividendStream::new_bump_all(&*divs, size)))
+                => RcDividendStream::new(Arc::new(DividendStream::new_bump_all(&*divs, size)))
         }
     }
 }

--- a/src/data/bumpvol.rs
+++ b/src/data/bumpvol.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 use std::f64::NAN;
 use data::volsurface::RcVolSurface;
 use data::volsurface::FlatVolSurface;
@@ -59,13 +59,13 @@ impl Bumper<RcVolSurface> for BumpVol {
     fn apply(&self, surface: RcVolSurface) -> RcVolSurface {
         match self {
             &BumpVol::FlatAdditive { size }
-                => RcVolSurface::new(Rc::new(ParallelBumpVol::new(surface.clone(), size))),
+                => RcVolSurface::new(Arc::new(ParallelBumpVol::new(surface.clone(), size))),
 
             &BumpVol::TimeScaled { size, floor }
-                => RcVolSurface::new(Rc::new(TimeScaledBumpVol::new(surface.clone(), size, floor))),
+                => RcVolSurface::new(Arc::new(TimeScaledBumpVol::new(surface.clone(), size, floor))),
 
             &BumpVol::Replace { vol }
-                => RcVolSurface::new(Rc::new(FlatVolSurface::new(vol, 
+                => RcVolSurface::new(Arc::new(FlatVolSurface::new(vol, 
                     surface.calendar().clone(), surface.base_date())))
         }
     }

--- a/src/data/bumpyield.rs
+++ b/src/data/bumpyield.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 use data::curves::AnnualisedFlatBump;
 use data::curves::ContinuouslyCompoundedFlatBump;
 use data::bump::Bumper;
@@ -26,14 +26,14 @@ impl Bumper<RcRateCurve> for BumpYield {
     fn apply(&self, surface: RcRateCurve) -> RcRateCurve {
         match self {
             &BumpYield::FlatAnnualised { size }
-                => RcRateCurve::new(Rc::new(AnnualisedFlatBump::new(
+                => RcRateCurve::new(Arc::new(AnnualisedFlatBump::new(
                     surface.clone(), size))),
 
             // Note that an alternative methodology here would be to
             // bump the pillars. Consider this if profiling shows this
             // to be a bottleneck.
             &BumpYield::FlatContinuouslyCompounded { size }
-                => RcRateCurve::new(Rc::new(ContinuouslyCompoundedFlatBump::new(
+                => RcRateCurve::new(Arc::new(ContinuouslyCompoundedFlatBump::new(
                     surface.clone(), size)))
         }
     }

--- a/src/data/divstream.rs
+++ b/src/data/divstream.rs
@@ -5,7 +5,7 @@ use data::curves::RelativeBump;
 use data::forward::log_discount_with_borrow;
 use data::forward::discount_with_borrow;
 use core::qm;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::f64::NAN;
 use std::ops::Deref;
 use serde as sd;
@@ -113,7 +113,7 @@ impl DividendStream {
            div.bump_all_relative(one_plus_bump);
         }
 
-        let bumped_yield = RcRateCurve::new(Rc::new(RelativeBump::new(divs.div_yield(), bump))); 
+        let bumped_yield = RcRateCurve::new(Arc::new(RelativeBump::new(divs.div_yield(), bump))); 
 
         DividendStream {
             dividends: bumped_divs,
@@ -129,10 +129,10 @@ impl DividendStream {
 /// Create a type RcDividendStream to allow us to implement serialization
 /// and deserialization
 #[derive(Clone, Debug)]
-pub struct RcDividendStream(Rc<DividendStream>);
+pub struct RcDividendStream(Arc<DividendStream>);
 
 impl RcDividendStream {
-    pub fn new(stream: Rc<DividendStream>) -> RcDividendStream {
+    pub fn new(stream: Arc<DividendStream>) -> RcDividendStream {
         RcDividendStream(stream)
     }
 }
@@ -157,7 +157,7 @@ impl<'de> sd::Deserialize<'de> for RcDividendStream {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where D: sd::Deserializer<'de> {
         let stream = DividendStream::deserialize(deserializer)?;
-        Ok(RcDividendStream::new(Rc::new(stream)))
+        Ok(RcDividendStream::new(Arc::new(stream)))
     }
 }
 
@@ -486,7 +486,7 @@ mod tests {
             (d + 365 * 5, 0.01), (d + 365 * 10, 0.015)];
         let curve = RateCurveAct365::new(d + 365 * 2, &points,
             Extrap::Zero, Extrap::Flat).unwrap();
-        let div_yield = RcRateCurve::new(Rc::new(curve));
+        let div_yield = RcRateCurve::new(Arc::new(curve));
 
         DividendStream::new(&divs, div_yield) 
     }

--- a/src/data/fixings.rs
+++ b/src/data/fixings.rs
@@ -2,7 +2,7 @@ use dates::Date;
 use dates::datetime::DateTime;
 use core::qm;
 use std::collections::HashMap;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::ops::Deref;
 use serde as sd;
 
@@ -111,10 +111,10 @@ fn duplicate_fixing_curve(id: &str) -> qm::Error {
 /// Create a new type for a Rc<FixingTable> so we can implement serialize
 /// and deserialize functions for it.
 #[derive(Clone, Debug)]
-pub struct RcFixingTable(Rc<FixingTable>);
+pub struct RcFixingTable(Arc<FixingTable>);
 
 impl RcFixingTable {
-    pub fn new(table: Rc<FixingTable>) -> RcFixingTable {
+    pub fn new(table: Arc<FixingTable>) -> RcFixingTable {
         RcFixingTable(table)
     }
 }
@@ -139,7 +139,7 @@ impl<'de> sd::Deserialize<'de> for RcFixingTable {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where D: sd::Deserializer<'de> {
         let stream = FixingTable::deserialize(deserializer)?;
-        Ok(RcFixingTable::new(Rc::new(stream)))
+        Ok(RcFixingTable::new(Arc::new(stream)))
     }
 }
 

--- a/src/data/voldecorators.rs
+++ b/src/data/voldecorators.rs
@@ -1,4 +1,4 @@
-use std::rc::Rc;
+use std::sync::Arc;
 use data::volsurface::VolSurface;
 use data::volsurface::RcVolSurface;
 use data::forward::Forward;
@@ -35,7 +35,7 @@ impl ConstantExpiryTimeEvolution {
     }
 
     pub fn from_serial<'de>(de: &mut esd::Deserializer<'de>) -> Result<RcVolSurface, esd::Error> {
-        Ok(Qrc::new(Rc::new(ConstantExpiryTimeEvolution::deserialize(de)?)))
+        Ok(Qrc::new(Arc::new(ConstantExpiryTimeEvolution::deserialize(de)?)))
     }
 }
 
@@ -107,7 +107,7 @@ impl RollingExpiryTimeEvolution {
     }
 
     pub fn from_serial<'de>(de: &mut esd::Deserializer<'de>) -> Result<RcVolSurface, esd::Error> {
-        Ok(Qrc::new(Rc::new(RollingExpiryTimeEvolution::deserialize(de)?)))
+        Ok(Qrc::new(Arc::new(RollingExpiryTimeEvolution::deserialize(de)?)))
     }
 }
 
@@ -180,7 +180,7 @@ impl ParallelBumpVol {
     }
 
     pub fn from_serial<'de>(de: &mut esd::Deserializer<'de>) -> Result<RcVolSurface, esd::Error> {
-        Ok(Qrc::new(Rc::new(ParallelBumpVol::deserialize(de)?)))
+        Ok(Qrc::new(Arc::new(ParallelBumpVol::deserialize(de)?)))
     }
 }
 
@@ -247,7 +247,7 @@ impl TimeScaledBumpVol {
     }
 
     pub fn from_serial<'de>(de: &mut esd::Deserializer<'de>) -> Result<RcVolSurface, esd::Error> {
-        Ok(Qrc::new(Rc::new(TimeScaledBumpVol::deserialize(de)?)))
+        Ok(Qrc::new(Arc::new(TimeScaledBumpVol::deserialize(de)?)))
     }
 }
 
@@ -300,7 +300,7 @@ impl VolSurface for TimeScaledBumpVol {
 pub struct StickyDeltaBumpVol {
     base_vol: RcVolSurface,
     #[serde(skip)]
-    bumped_forward: Rc<Forward>
+    bumped_forward: Arc<Forward>
 }
 
 impl TypeId for StickyDeltaBumpVol {
@@ -308,7 +308,7 @@ impl TypeId for StickyDeltaBumpVol {
 }
 
 impl StickyDeltaBumpVol {
-    pub fn new(base_vol: RcVolSurface, bumped_forward: Rc<Forward>)
+    pub fn new(base_vol: RcVolSurface, bumped_forward: Arc<Forward>)
         -> StickyDeltaBumpVol {
         StickyDeltaBumpVol { base_vol: base_vol, 
             bumped_forward: bumped_forward }
@@ -401,7 +401,7 @@ mod tests {
     fn constant_expiry_vol_surface() {
 
         let base_date = DateDayFraction::new(Date::from_ymd(2012, 05, 25), 0.2);
-        let unbumped = RcVolSurface::new(Rc::new(sample_vol_surface(base_date)));
+        let unbumped = RcVolSurface::new(Arc::new(sample_vol_surface(base_date)));
         let bump = 2.0 / 252.0;
         let bumped_base = base_date + 2;
         let bumped = ConstantExpiryTimeEvolution::new(unbumped.clone(), bump,
@@ -429,7 +429,7 @@ mod tests {
         // to do the modification. Note that we add four days because 
         // 2012-05-25 is a Friday and we want to add two business days.
         let base_date = DateDayFraction::new(Date::from_ymd(2012, 05, 25), 0.2);
-        let unbumped = RcVolSurface::new(Rc::new(sample_vol_surface(base_date)));
+        let unbumped = RcVolSurface::new(Arc::new(sample_vol_surface(base_date)));
         let dynamics = VolTimeDynamics::ConstantExpiry;
         let mut bumped = unbumped.clone();
         dynamics.modify(&mut bumped, base_date.date() + 4).unwrap();
@@ -457,7 +457,7 @@ mod tests {
     fn rolling_expiry_vol_surface() {
 
         let base_date = DateDayFraction::new(Date::from_ymd(2012, 05, 25), 0.0);
-        let unbumped = RcVolSurface::new(Rc::new(sample_vol_surface(base_date)));
+        let unbumped = RcVolSurface::new(Arc::new(sample_vol_surface(base_date)));
         let bump = 5.0 / 252.0;
         let bumped = RollingExpiryTimeEvolution::new(unbumped.clone(), bump,
             base_date + 7);
@@ -489,7 +489,7 @@ mod tests {
         // same as the previous test, but this time we use the dynamics enum
         // to do the modification
         let base_date = DateDayFraction::new(Date::from_ymd(2012, 05, 25), 0.0);
-        let unbumped = RcVolSurface::new(Rc::new(sample_vol_surface(base_date)));
+        let unbumped = RcVolSurface::new(Arc::new(sample_vol_surface(base_date)));
         let dynamics = VolTimeDynamics::RollingExpiry;
         let mut bumped = unbumped.clone();
         dynamics.modify(&mut bumped, base_date.date() + 7).unwrap();
@@ -519,7 +519,7 @@ mod tests {
     fn parallel_bumped_vol_surface() {
 
         let base_date = DateDayFraction::new(Date::from_ymd(2012, 05, 25), 0.2);
-        let unbumped = RcVolSurface::new(Rc::new(sample_vol_surface(base_date)));
+        let unbumped = RcVolSurface::new(Arc::new(sample_vol_surface(base_date)));
         let bump = 0.01;
         let bumped = ParallelBumpVol::new(unbumped.clone(), bump);
 
@@ -540,7 +540,7 @@ mod tests {
     fn scaled_bumped_vol_surface() {
 
         let base_date = DateDayFraction::new(Date::from_ymd(2012, 05, 25), 0.2);
-        let unbumped = RcVolSurface::new(Rc::new(sample_vol_surface(base_date)));
+        let unbumped = RcVolSurface::new(Arc::new(sample_vol_surface(base_date)));
         let bump = 0.01;
         let floor = 1.0 / 12.0;
         let bumped = TimeScaledBumpVol::new(unbumped.clone(), bump, floor);
@@ -563,7 +563,7 @@ mod tests {
     fn sticky_delta_bumped_vol_surface() {
 
         let base_date = DateDayFraction::new(Date::from_ymd(2012, 05, 25), 0.0);
-        let unbumped = RcVolSurface::new(Rc::new(sample_vol_surface(base_date)));
+        let unbumped = RcVolSurface::new(Arc::new(sample_vol_surface(base_date)));
     
         // these points are 10% larger than those in the sample surface
         let d = base_date.date();
@@ -571,7 +571,7 @@ mod tests {
             (d+120, 99.0), (d+240, 98.89), (d+480, 98.78), (d+960, 98.78)];
         let cs = Box::new(Linear::new(&points,
             Extrap::Natural, Extrap::Natural).unwrap());
-        let fwd = Rc::new(InterpolatedForward::new(cs));
+        let fwd = Arc::new(InterpolatedForward::new(cs));
 
         let bumped = StickyDeltaBumpVol::new(unbumped.clone(), fwd);
 

--- a/src/dates/calendar.rs
+++ b/src/dates/calendar.rs
@@ -2,7 +2,7 @@ use dates::Date;
 use dates::datetime::DateDayFraction;
 use std::cmp::max;
 use std::fmt::Debug;
-use std::rc::Rc;
+use std::sync::Arc;
 use erased_serde as esd;
 use serde as sd;
 use serde_tagged as sdt;
@@ -16,7 +16,7 @@ use core::factories::Qrc;
 /// business day volatility, settlement calculations, and the roll-out of
 /// schedules for exotic products and swaps.
   
-pub trait Calendar : esd::Serialize + TypeId + Debug {
+pub trait Calendar : esd::Serialize + TypeId + Sync + Send + Debug {
     /// The name of this calendar. Conventionally, the name is a three-letter
     /// upper-case string such as "TGT" or "NYS", though this is not required.
     fn name(&self) -> &str;
@@ -123,7 +123,7 @@ impl EveryDayCalendar {
     pub fn new() -> EveryDayCalendar { EveryDayCalendar {} }
 
     pub fn from_serial<'de>(de: &mut esd::Deserializer<'de>) -> Result<RcCalendar, esd::Error> {
-        Ok(Qrc::new(Rc::new(EveryDayCalendar::deserialize(de)?)))
+        Ok(Qrc::new(Arc::new(EveryDayCalendar::deserialize(de)?)))
     }
 }
 
@@ -178,7 +178,7 @@ impl WeekdayCalendar {
     }
 
     pub fn from_serial<'de>(de: &mut esd::Deserializer<'de>) -> Result<RcCalendar, esd::Error> {
-        Ok(Qrc::new(Rc::new(WeekdayCalendar::deserialize(de)?)))
+        Ok(Qrc::new(Arc::new(WeekdayCalendar::deserialize(de)?)))
     }
 }
 
@@ -304,7 +304,7 @@ impl WeekdayAndHolidayCalendar {
     }
 
     pub fn from_serial<'de>(de: &mut esd::Deserializer<'de>) -> Result<RcCalendar, esd::Error> {
-        Ok(Qrc::new(Rc::new(WeekdayAndHolidayCalendar::deserialize(de)?)))
+        Ok(Qrc::new(Arc::new(WeekdayAndHolidayCalendar::deserialize(de)?)))
     }
 
     // Finds the next holiday, including the day we start from, and returns
@@ -501,7 +501,7 @@ impl VolatilityCalendar {
     }
 
     pub fn from_serial<'de>(de: &mut esd::Deserializer<'de>) -> Result<RcCalendar, esd::Error> {
-        Ok(Qrc::new(Rc::new(VolatilityCalendar::deserialize(de)?)))
+        Ok(Qrc::new(Arc::new(VolatilityCalendar::deserialize(de)?)))
     }
 }
 
@@ -937,7 +937,7 @@ mod tests {
 
     fn new_test_volatility_calendar() -> VolatilityCalendar {
         let calendar = new_test_calendar();
-        VolatilityCalendar::new("VOL", Qrc::new(Rc::new(calendar)), 0.25)
+        VolatilityCalendar::new("VOL", Qrc::new(Arc::new(calendar)), 0.25)
     }
 }
 

--- a/src/facade/mod.rs
+++ b/src/facade/mod.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 use serde_json as sdj;
 use risk::ReportTolerances;
 use std::io::{Read, Write};
-use std::rc::Rc;
+use std::sync::Arc;
 use std::fmt;
 
 /// An instrument in QuantMath represents any tradable item. At simplest, it can be
@@ -43,7 +43,7 @@ pub fn instrument_from_json(source: &mut Read,
     let currencies_map = dedup_map_from_slice(currencies);
     let instruments_map = dedup_map_from_slice(instruments);
 
-    let mut ccy = Dedup::<Currency, Rc<Currency>>::new(ccy_dedup, currencies_map);
+    let mut ccy = Dedup::<Currency, Arc<Currency>>::new(ccy_dedup, currencies_map);
     let mut opt = Dedup::<Instrument, Qrc<Instrument>>::new(instr_dedup, instruments_map);
     let instr = ccy.with(&DEDUP_CURRENCY, 
         || opt.with(&DEDUP_INSTRUMENT,

--- a/src/math/interpolation.rs
+++ b/src/math/interpolation.rs
@@ -10,7 +10,7 @@ use core::qm;
 
 /// To use interpolation, the types along the x axis must be Interpolable
 
-pub trait Interpolable<T> {
+pub trait Interpolable<T> : Sync + Send {
 
     /// Expresses the difference between two points on the x-axis as a
     /// floating point number.
@@ -63,7 +63,7 @@ pub trait FlyweightInterpolate<T> where T : Interpolable<T> {
 /// Interpolation with date or number for the abscissa and number for the
 /// ordinal. In this implementation, the array of points is supplied in
 /// the constructor to the interpolation object.
-pub trait Interpolate<T> where T : Interpolable<T> {
+pub trait Interpolate<T> : Sync + Send where T : Interpolable<T> {
     fn interpolate(&self, x: T) -> Result<f64, qm::Error>;
 }
 

--- a/src/models/blackdiffusion.rs
+++ b/src/models/blackdiffusion.rs
@@ -1,7 +1,7 @@
 use std::any::Any;
 use std::collections::HashMap;
 use std::ops::Deref;
-use std::rc::Rc;
+use std::sync::Arc;
 use rand;
 use rand::StdRng;
 use nalgebra::linalg::Cholesky;
@@ -60,7 +60,7 @@ impl BlackDiffusionFactory {
     }
 
     pub fn from_serial<'de>(de: &mut esd::Deserializer<'de>) -> Result<Qrc<MonteCarloModelFactory>, esd::Error> {
-        Ok(Qrc::new(Rc::new(BlackDiffusionFactory::deserialize(de)?)))
+        Ok(Qrc::new(Arc::new(BlackDiffusionFactory::deserialize(de)?)))
     }
 }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -21,7 +21,7 @@ use std::fmt::Debug;
 
 /// Interface that must be implemented by a model factory in order to support
 /// Monte-Carlo pricing.
-pub trait MonteCarloModelFactory : esd::Serialize + TypeId + Debug {
+pub trait MonteCarloModelFactory : esd::Serialize + TypeId + Sync + Send + Debug {
  
     /// Given a timeline (which also specifies the underlyings we need to
     /// evolve), and a pricing context, create a Monte-Carlo model.

--- a/src/pricers/mod.rs
+++ b/src/pricers/mod.rs
@@ -17,7 +17,7 @@ use std::fmt::Debug;
 
 /// Pricers are always constructed using a pricer factory. This means that the
 /// code to create the pricer is independent of what sort of pricer it is.
-pub trait PricerFactory : esd::Serialize + TypeId + Debug {
+pub trait PricerFactory : esd::Serialize + TypeId + Sync + Send + Debug {
     /// Creates a pricer, given all the data that is needed to get a price.
     /// All the inputs are shared pointers to const objects, which allows them
     /// to be shared across multiple pricers. (Consider making them Arc rather

--- a/src/pricers/montecarlo.rs
+++ b/src/pricers/montecarlo.rs
@@ -1,5 +1,5 @@
 use core::qm;
-use std::rc::Rc;
+use std::sync::Arc;
 use instruments::RcInstrument;
 use instruments::PricingContext;
 use instruments::DependencyContext;
@@ -57,7 +57,7 @@ impl MonteCarloPricerFactory {
     }
 
     pub fn from_serial<'de>(de: &mut esd::Deserializer<'de>) -> Result<Qrc<PricerFactory>, esd::Error> {
-        Ok(Qrc::new(Rc::new(MonteCarloPricerFactory::deserialize(de)?)))
+        Ok(Qrc::new(Arc::new(MonteCarloPricerFactory::deserialize(de)?)))
     }
 }
 
@@ -107,7 +107,7 @@ impl MonteCarloPricer {
 
         // Create a cached pricing context, prefetching the data to price them
         let context = Box::new(PricingContextPrefetch::new(market_data,
-            Rc::new(dependencies))?);
+            Arc::new(dependencies))?);
 
         // Create a Monte-Carlo model
         let model = model_factory.factory(&timeline, context)?;
@@ -183,7 +183,7 @@ impl TimeBumpable for MonteCarloPricer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::rc::Rc;
+    use std::sync::Arc;
     use dates::Date;
     use dates::datetime::DateTime;
     use dates::datetime::TimeOfDay;
@@ -215,14 +215,14 @@ mod tests {
         // from the self-pricer bumped prices. Thus all these tests validate
         // the Monte-Carlo pricing against analytic.
 
-        let market_data = RcMarketData::new(Rc::new(sample_market_data()));
+        let market_data = RcMarketData::new(Arc::new(sample_market_data()));
         let instrument = RcInstrument::new(Qrc::new(sample_european()));
-        let fixings = RcFixingTable::new(Rc::new(sample_fixings()));
+        let fixings = RcFixingTable::new(Arc::new(sample_fixings()));
 
         let n_paths = 100000;
         let correlation_substep = 20;
         let path_substep = 0.01;
-        let model_factory = RcMonteCarloModelFactory::new(Rc::new(BlackDiffusionFactory::new(
+        let model_factory = RcMonteCarloModelFactory::new(Arc::new(BlackDiffusionFactory::new(
             correlation_substep, path_substep, n_paths)));
         let factory = MonteCarloPricerFactory::new(model_factory);
         let mut pricer = factory.new(instrument, fixings, market_data).unwrap();
@@ -309,14 +309,14 @@ mod tests {
         // from the self-pricer bumped prices. Thus all these tests validate
         // the Monte-Carlo pricing against analytic.
 
-        let market_data = RcMarketData::new(Rc::new(sample_market_data()));
+        let market_data = RcMarketData::new(Arc::new(sample_market_data()));
         let instrument = RcInstrument::new(Qrc::new(sample_forward_european()));
-        let fixings = RcFixingTable::new(Rc::new(sample_fixings()));
+        let fixings = RcFixingTable::new(Arc::new(sample_fixings()));
 
         let n_paths = 100000;
         let correlation_substep = 20;
         let path_substep = 0.01;
-        let model_factory = RcMonteCarloModelFactory::new(Rc::new(BlackDiffusionFactory::new(
+        let model_factory = RcMonteCarloModelFactory::new(Arc::new(BlackDiffusionFactory::new(
             correlation_substep, path_substep, n_paths)));
         let factory = MonteCarloPricerFactory::new(model_factory);
         let mut pricer = factory.new(instrument, fixings, market_data).unwrap();

--- a/src/pricers/selfpricer.rs
+++ b/src/pricers/selfpricer.rs
@@ -1,5 +1,5 @@
 use core::qm;
-use std::rc::Rc;
+use std::sync::Arc;
 use instruments::RcInstrument;
 use instruments::PricingContext;
 use instruments::DependencyContext;
@@ -47,7 +47,7 @@ impl SelfPricerFactory {
     }
 
     pub fn from_serial<'de>(de: &mut esd::Deserializer<'de>) -> Result<Qrc<PricerFactory>, esd::Error> {
-        Ok(Qrc::new(Rc::new(SelfPricerFactory::deserialize(de)?)))
+        Ok(Qrc::new(Arc::new(SelfPricerFactory::deserialize(de)?)))
     }
 }
 
@@ -89,7 +89,7 @@ impl SelfPricer {
 
         // Create a cached pricing context, prefetching the data to price them
         let context = PricingContextPrefetch::new(&*market_data,
-            Rc::new(dependencies))?;
+            Arc::new(dependencies))?;
 
         Ok(SelfPricer { instruments: instruments, context: context })
     }
@@ -161,7 +161,7 @@ impl TimeBumpable for SelfPricer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::rc::Rc;
+    use std::sync::Arc;
     use dates::Date;
     use dates::datetime::DateTime;
     use dates::datetime::TimeOfDay;
@@ -190,9 +190,9 @@ mod tests {
     #[test]
     fn self_price_european_bumped_price() {
 
-        let market_data = RcMarketData::new(Rc::new(sample_market_data()));
+        let market_data = RcMarketData::new(Arc::new(sample_market_data()));
         let instrument = RcInstrument::new(Qrc::new(sample_european()));
-        let fixings = RcFixingTable::new(Rc::new(sample_fixings()));
+        let fixings = RcFixingTable::new(Arc::new(sample_fixings()));
 
         let factory = SelfPricerFactory::new();
         let mut pricer = factory.new(instrument, fixings, market_data).unwrap();
@@ -274,9 +274,9 @@ mod tests {
     #[test]
     fn self_price_forward_european_time_bumped() {
 
-        let market_data = RcMarketData::new(Rc::new(sample_market_data()));
+        let market_data = RcMarketData::new(Arc::new(sample_market_data()));
         let instrument = RcInstrument::new(Qrc::new(sample_forward_european()));
-        let fixings = RcFixingTable::new(Rc::new(sample_fixings()));
+        let fixings = RcFixingTable::new(Arc::new(sample_fixings()));
 
         let factory = SelfPricerFactory::new();
         let mut pricer = factory.new(instrument, fixings, market_data).unwrap();
@@ -335,7 +335,7 @@ mod tests {
     fn serde_self_pricer_roundtrip() {
 
         // create some sample data
-        let factory = RcPricerFactory::new(Rc::new(SelfPricerFactory::new()));
+        let factory = RcPricerFactory::new(Arc::new(SelfPricerFactory::new()));
 
         // round trip it via JSON
         let serialized = serde_json::to_string_pretty(&factory).unwrap();

--- a/src/risk/deltagamma.rs
+++ b/src/risk/deltagamma.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::any::Any;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::fmt;
 use math::numerics::{ApproxEq, approx_eq};
 use risk::Report;
@@ -125,7 +125,7 @@ impl DeltaGammaReportGenerator {
     }
 
     pub fn from_serial<'de>(de: &mut esd::Deserializer<'de>) -> Result<Qrc<ReportGenerator>, esd::Error> {
-        Ok(Qrc::new(Rc::new(DeltaGammaReportGenerator::deserialize(de)?)))
+        Ok(Qrc::new(Arc::new(DeltaGammaReportGenerator::deserialize(de)?)))
     }
 }
 
@@ -299,7 +299,7 @@ pub mod tests {
     fn serde_delta_gamma_generator_roundtrip() {
 
         // create some sample data
-        let generator = RcReportGenerator::new(Rc::new(DeltaGammaReportGenerator::new(0.01)));
+        let generator = RcReportGenerator::new(Arc::new(DeltaGammaReportGenerator::new(0.01)));
 
         // round trip it via JSON
         let serialized = serde_json::to_string_pretty(&generator).unwrap();

--- a/src/risk/dependencies.rs
+++ b/src/risk/dependencies.rs
@@ -209,17 +209,17 @@ mod tests {
     use instruments::options::OptionSettlement;
     use dates::rules::RcDateRule;
     use core::factories::Qrc;
-    use std::rc::Rc;
+    use std::sync::Arc;
 
     fn sample_currency(step: u32) -> Currency {
-        let calendar = RcCalendar::new(Rc::new(WeekdayCalendar::new()));
-        let settlement = RcDateRule::new(Rc::new(BusinessDays::new_step(calendar, step)));
+        let calendar = RcCalendar::new(Arc::new(WeekdayCalendar::new()));
+        let settlement = RcDateRule::new(Arc::new(BusinessDays::new_step(calendar, step)));
         Currency::new("GBP", settlement)
     }
 
     fn sample_settlement(step: u32) -> RcDateRule {
-        let calendar = RcCalendar::new(Rc::new(WeekdayCalendar::new()));
-        RcDateRule::new(Rc::new(BusinessDays::new_step(calendar, step)))
+        let calendar = RcCalendar::new(Arc::new(WeekdayCalendar::new()));
+        RcDateRule::new(Arc::new(BusinessDays::new_step(calendar, step)))
     }
 
     fn sample_equity(currency: RcCurrency, step: u32) -> Equity {
@@ -235,14 +235,14 @@ mod tests {
         let short_expiry = DateTime::new(d+70, TimeOfDay::Close);
         let long_expiry = DateTime::new(d+210, TimeOfDay::Close);
 
-        let currency = RcCurrency::new(Rc::new(sample_currency(2)));
+        let currency = RcCurrency::new(Arc::new(sample_currency(2)));
         let settlement = sample_settlement(2);
-        let equity: RcInstrument = RcInstrument::new(Qrc::new(Rc::new(sample_equity(currency, 2))));
-        let short_european: RcInstrument = RcInstrument::new(Qrc::new(Rc::new(SpotStartingEuropean::new(
+        let equity: RcInstrument = RcInstrument::new(Qrc::new(Arc::new(sample_equity(currency, 2))));
+        let short_european: RcInstrument = RcInstrument::new(Qrc::new(Arc::new(SpotStartingEuropean::new(
             "ShortDatedEquity",
             "OPT", equity.clone(), settlement.clone(), short_expiry,
             strike, PutOrCall::Call, OptionSettlement::Cash).unwrap())));
-        let long_european: RcInstrument = RcInstrument::new(Qrc::new(Rc::new(SpotStartingEuropean::new(
+        let long_european: RcInstrument = RcInstrument::new(Qrc::new(Arc::new(SpotStartingEuropean::new(
             "LongDatedEquity",
             "OPT", equity.clone(), settlement, long_expiry,
             strike, PutOrCall::Call, OptionSettlement::Cash).unwrap())));

--- a/src/risk/mod.rs
+++ b/src/risk/mod.rs
@@ -170,7 +170,7 @@ impl ReportTolerances {
 
 /// A report generator performs all the calculations needed to produce a
 /// report.
-pub trait ReportGenerator : esd::Serialize + TypeId + Debug {
+pub trait ReportGenerator : esd::Serialize + TypeId + Sync + Send + Debug {
     /// Perform all the calculations, bumping, pricing and possibly cloning
     /// the input pricer to generate the result. Normally the pricer is left
     /// in the same state as it started, unless it documents otherwise.

--- a/src/risk/timebumped.rs
+++ b/src/risk/timebumped.rs
@@ -8,7 +8,7 @@ use risk::ApproxEqReport;
 use risk::bumptime::BumpTime;
 use risk::ReportTolerances;
 use std::any::Any;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::fmt;
 use math::numerics::{ApproxEq, approx_eq};
 use core::qm;
@@ -109,7 +109,7 @@ impl TimeBumpedReportGenerator {
     }
 
     pub fn from_serial<'de>(de: &mut esd::Deserializer<'de>) -> Result<Qrc<ReportGenerator>, esd::Error> {
-        Ok(Qrc::new(Rc::new(TimeBumpedReportGenerator::deserialize(de)?)))
+        Ok(Qrc::new(Arc::new(TimeBumpedReportGenerator::deserialize(de)?)))
     }
 }
 
@@ -183,8 +183,8 @@ mod tests {
         let theta_date = pricer.as_bumpable().context().spot_date() + 1;
         let bump = BumpTime::new(theta_date, theta_date, SpotDynamics::StickyForward);
         let mut generator = TimeBumpedReportGenerator::new(bump);
-        generator.add(RcReportGenerator::new(Rc::new(DeltaGammaReportGenerator::new(0.01))));
-        generator.add(RcReportGenerator::new(Rc::new(VegaVolgaReportGenerator::new(BumpVol::new_flat_additive(0.01)))));
+        generator.add(RcReportGenerator::new(Arc::new(DeltaGammaReportGenerator::new(0.01))));
+        generator.add(RcReportGenerator::new(Arc::new(VegaVolgaReportGenerator::new(BumpVol::new_flat_additive(0.01)))));
         let mut save = pricer.as_bumpable().new_saveable();
         let report = generator.generate(&mut *pricer, &mut *save, unbumped).unwrap();
         let results = report.as_any().downcast_ref::<TimeBumpedReport>().unwrap();

--- a/src/risk/vegavolga.rs
+++ b/src/risk/vegavolga.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::any::Any;
-use std::rc::Rc;
+use std::sync::Arc;
 use std::fmt;
 use math::numerics::{ApproxEq, approx_eq};
 use risk::Report;
@@ -134,7 +134,7 @@ impl VegaVolgaReportGenerator {
     }
 
     pub fn from_serial<'de>(de: &mut esd::Deserializer<'de>) -> Result<Qrc<ReportGenerator>, esd::Error> {
-        Ok(Qrc::new(Rc::new(VegaVolgaReportGenerator::deserialize(de)?)))
+        Ok(Qrc::new(Arc::new(VegaVolgaReportGenerator::deserialize(de)?)))
     }
 }
 


### PR DESCRIPTION
Added Send + Sync to all the objects that are passed through the external interface, as we have no way of policing whether they are used in different threads. Fix all the compile errors that result.

The effect is that all Rc containers are now Arc. This makes sense, as we really only use sharing when external users want it. For example, a user may use the same instrument and market data in different threads. It adds an overhead to cloning an Arc, but we do not do that very often.